### PR TITLE
Index into values with at, and more generic/extra accessors/constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ from_string = [
 # Enable serde support for serializing/deserializing Values.
 serde = [
     "dep:serde",
-    "bitvec/serde"
 ]
 # Signal that the target architecture is 32bit. Enabled internally
 # if pointer_width != "64", but can be enabled here for testing.
@@ -32,9 +31,9 @@ serde = [
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 serde = { version = "1.0.124", features = ["derive"], optional = true }
-frame-metadata = "15.0.0"
+frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 thiserror = "1.0.24"
-scale-info = { version = "2.0.0", features = ["bit-vec"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["bit-vec", "std"] }
 either = "1.6.1"
 yap = { version = "0.7.2", optional = true }
 

--- a/src/at.rs
+++ b/src/at.rs
@@ -32,14 +32,14 @@ use super::{Composite, Value, ValueDef, Variant};
 /// ```
 /// use scale_value::{ Value, At };
 ///
-/// let val = Value::named_composite(vec![
-///     ("hello".to_string(), Value::unnamed_composite(vec![
+/// let val = Value::named_composite([
+///     ("hello", Value::unnamed_composite([
 ///         Value::u128(1),
 ///         Value::bool(true),
-///         Value::named_composite(vec![
-///             ("wibble".to_string(), Value::bool(false)),
-///             ("foo".to_string(), Value::named_composite(vec![
-///                 ("bar".to_string(), Value::u128(123))
+///         Value::named_composite([
+///             ("wibble", Value::bool(false)),
+///             ("foo", Value::named_composite([
+///                 ("bar", Value::u128(123))
 ///             ]))
 ///         ])
 ///     ]))

--- a/src/at.rs
+++ b/src/at.rs
@@ -1,0 +1,246 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the scale-value crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Indexing into Value's to access things. We can't use the `Index` trait,
+// since it returns references, and we can't necessarily give back a reference
+// (`serde_json::Value` uses a statically initialised value to give back a ref
+// to in these cases, but we have a generic `Ctx` and can't do that ourselves).
+
+use super::{Composite, Value, ValueDef, Variant};
+
+/// This trait allows indexing into [`Value`]s (and options of [`Value`]s)
+/// using the [`At::at()`] function. It's a little like Rust's [`std::ops::Index`]
+/// trait, but adapted so that we can return and work with optionals.
+///
+/// Indexing into a [`Value`] never panics; instead it will return `None` if a
+/// value at the given location cannot be found.
+///
+/// # Example
+///
+/// ```
+/// use scale_value::{ Value, At };
+///
+/// let val = Value::named_composite(vec![
+///     ("hello".to_string(), Value::unnamed_composite(vec![
+///         Value::u128(1),
+///         Value::bool(true),
+///         Value::named_composite(vec![
+///             ("wibble".to_string(), Value::bool(false)),
+///             ("foo".to_string(), Value::named_composite(vec![
+///                 ("bar".to_string(), Value::u128(123))
+///             ]))
+///         ])
+///     ]))
+/// ]);
+///
+/// // Use `at` to access nested values:
+/// assert_eq!(val.at("hello").at(0), Some(&Value::u128(1)));
+/// assert_eq!(val.at("hello").at(1), Some(&Value::bool(true)));
+/// assert_eq!(val.at("hello").at(2).at("wibble"), Some(&Value::bool(false)));
+/// assert_eq!(val.at("hello").at(2).at("foo").at("bar"), Some(&Value::u128(123)));
+///
+/// // If the value doesn't exist, None will be returned:
+/// assert_eq!(val.at("wibble").at(3), None);
+/// assert_eq!(val.at("wibble").at("wobble").at("nope"), None);
+/// ```
+pub trait At<Ctx>: private::Sealed {
+	/// Index into a value, returning a reference to the value if one
+	/// exists, or [`None`] if not.
+	fn at<L: AsLocation>(&self, loc: L) -> Option<&Value<Ctx>>;
+}
+
+// Prevent users from implementing the At trait.
+mod private {
+	use super::*;
+	pub trait Sealed {}
+	impl<Ctx> Sealed for Value<Ctx> {}
+	impl<Ctx> Sealed for Composite<Ctx> {}
+	impl<Ctx> Sealed for Variant<Ctx> {}
+	impl<T: Sealed> Sealed for Option<&T> {}
+}
+
+impl<Ctx> At<Ctx> for Composite<Ctx> {
+	fn at<L: AsLocation>(&self, loc: L) -> Option<&Value<Ctx>> {
+		match loc.as_location().inner {
+			LocationInner::Str(s) => match self {
+				Composite::Named(vals) => {
+					vals.iter().find_map(|(n, v)| if s == n { Some(v) } else { None })
+				}
+				_ => None,
+			},
+			LocationInner::Usize(n) => match self {
+				Composite::Named(vals) => {
+					let val = vals.get(n);
+					val.map(|v| &v.1)
+				}
+				Composite::Unnamed(vals) => vals.get(n),
+			},
+		}
+	}
+}
+
+impl<Ctx> At<Ctx> for Variant<Ctx> {
+	fn at<L: AsLocation>(&self, loc: L) -> Option<&Value<Ctx>> {
+		self.values.at(loc)
+	}
+}
+
+impl<Ctx> At<Ctx> for Value<Ctx> {
+	fn at<L: AsLocation>(&self, loc: L) -> Option<&Value<Ctx>> {
+		match &self.value {
+			ValueDef::Composite(c) => c.at(loc),
+			ValueDef::Variant(v) => v.at(loc),
+			_ => None,
+		}
+	}
+}
+
+impl<Ctx, T: At<Ctx>> At<Ctx> for Option<&T> {
+	fn at<L: AsLocation>(&self, loc: L) -> Option<&Value<Ctx>> {
+		self.as_ref().and_then(|v| v.at(loc))
+	}
+}
+
+/// Types which can be used as a lookup location with [`At::at`]
+/// implement this trait.
+///
+/// Users cannot implement this as the [`Location`] type internals
+/// are opaque and subject to change.
+pub trait AsLocation {
+	fn as_location(&self) -> Location<'_>;
+}
+
+impl AsLocation for usize {
+	fn as_location(&self) -> Location<'_> {
+		Location { inner: LocationInner::Usize(*self) }
+	}
+}
+
+impl AsLocation for &str {
+	fn as_location(&self) -> Location<'_> {
+		Location { inner: LocationInner::Str(self) }
+	}
+}
+
+impl AsLocation for String {
+	fn as_location(&self) -> Location<'_> {
+		Location { inner: LocationInner::Str(&**self) }
+	}
+}
+
+impl<T: AsLocation> AsLocation for &T {
+	fn as_location(&self) -> Location<'_> {
+		(*self).as_location()
+	}
+}
+
+/// A struct representing a location to access in a [`Value`].
+#[derive(Copy, Clone)]
+pub struct Location<'a> {
+	inner: LocationInner<'a>,
+}
+
+#[derive(Copy, Clone)]
+enum LocationInner<'a> {
+	Usize(usize),
+	Str(&'a str),
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	// This is basically the doc example with a little extra.
+	#[test]
+	fn nested_accessing() {
+		let val = Value::named_composite(vec![(
+			"hello".to_string(),
+			Value::unnamed_composite(vec![
+				Value::u128(1),
+				Value::bool(true),
+				Value::named_composite(vec![
+					("wibble".to_string(), Value::bool(false)),
+					(
+						"foo".to_string(),
+						Value::named_composite(vec![("bar".to_string(), Value::u128(123))]),
+					),
+				]),
+			]),
+		)]);
+
+		assert_eq!(val.at("hello").at(0), Some(&Value::u128(1)));
+		assert_eq!(val.at("hello").at(1), Some(&Value::bool(true)));
+		assert_eq!(val.at("hello").at(2).at("wibble"), Some(&Value::bool(false)));
+		assert_eq!(val.at("hello").at(2).at("foo").at("bar"), Some(&Value::u128(123)));
+
+		assert_eq!(val.at("wibble").at(3), None);
+		assert_eq!(val.at("wibble").at("wobble").at("nope"), None);
+
+		// Strings can be used:
+		assert_eq!(val.at("hello".to_string()).at(0), Some(&Value::u128(1)));
+		// References to valid locations are fine too:
+		assert_eq!(val.at(&&"hello".to_string()).at(&&&0), Some(&Value::u128(1)));
+	}
+
+	#[test]
+	fn accessing_variants() {
+		let val = Value::named_variant(
+			"TheVariant",
+			vec![("foo".to_string(), Value::u128(12345)), ("bar".to_string(), Value::char('c'))],
+		);
+
+		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
+
+		let val = Value::unnamed_variant("TheVariant", vec![Value::u128(12345), Value::char('c')]);
+
+		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');
+
+		// We can use `at()` on the variant directly, too:
+
+		let val = Variant::named_fields(
+			"TheVariant",
+			vec![("foo".to_string(), Value::u128(12345)), ("bar".to_string(), Value::char('c'))],
+		);
+
+		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
+
+		let val = Variant::unnamed_fields("TheVariant", vec![Value::u128(12345), Value::char('c')]);
+
+		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');
+	}
+
+	#[test]
+	fn accessing_composites() {
+		// We already test accessing composite Values. This also checks that `at` works on
+		// the Composite type, too..
+
+		let val = Composite::Named(vec![
+			("foo".to_string(), Value::u128(12345)),
+			("bar".to_string(), Value::char('c')),
+		]);
+
+		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
+
+		let val = Composite::Unnamed(vec![Value::u128(12345), Value::char('c')]);
+
+		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
+		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');
+	}
+}

--- a/src/at.rs
+++ b/src/at.rs
@@ -165,17 +165,14 @@ mod test {
 	// This is basically the doc example with a little extra.
 	#[test]
 	fn nested_accessing() {
-		let val = Value::named_composite(vec![(
-			"hello".to_string(),
-			Value::unnamed_composite(vec![
+		let val = Value::named_composite([(
+			"hello",
+			Value::unnamed_composite([
 				Value::u128(1),
 				Value::bool(true),
-				Value::named_composite(vec![
-					("wibble".to_string(), Value::bool(false)),
-					(
-						"foo".to_string(),
-						Value::named_composite(vec![("bar".to_string(), Value::u128(123))]),
-					),
+				Value::named_composite([
+					("wibble", Value::bool(false)),
+					("foo", Value::named_composite([("bar", Value::u128(123))])),
 				]),
 			]),
 		)]);
@@ -189,22 +186,22 @@ mod test {
 		assert_eq!(val.at("wibble").at("wobble").at("nope"), None);
 
 		// Strings can be used:
-		assert_eq!(val.at("hello".to_string()).at(0), Some(&Value::u128(1)));
+		assert_eq!(val.at("hello").at(0), Some(&Value::u128(1)));
 		// References to valid locations are fine too:
-		assert_eq!(val.at(&&"hello".to_string()).at(&&&0), Some(&Value::u128(1)));
+		assert_eq!(val.at(&&"hello").at(&&&0), Some(&Value::u128(1)));
 	}
 
 	#[test]
 	fn accessing_variants() {
 		let val = Value::named_variant(
 			"TheVariant",
-			vec![("foo".to_string(), Value::u128(12345)), ("bar".to_string(), Value::char('c'))],
+			[("foo", Value::u128(12345)), ("bar", Value::char('c'))],
 		);
 
 		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
 
-		let val = Value::unnamed_variant("TheVariant", vec![Value::u128(12345), Value::char('c')]);
+		let val = Value::unnamed_variant("TheVariant", [Value::u128(12345), Value::char('c')]);
 
 		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');
@@ -213,13 +210,13 @@ mod test {
 
 		let val = Variant::named_fields(
 			"TheVariant",
-			vec![("foo".to_string(), Value::u128(12345)), ("bar".to_string(), Value::char('c'))],
+			[("foo", Value::u128(12345)), ("bar", Value::char('c'))],
 		);
 
 		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
 
-		let val = Variant::unnamed_fields("TheVariant", vec![Value::u128(12345), Value::char('c')]);
+		let val = Variant::unnamed_fields("TheVariant", [Value::u128(12345), Value::char('c')]);
 
 		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');
@@ -230,15 +227,12 @@ mod test {
 		// We already test accessing composite Values. This also checks that `at` works on
 		// the Composite type, too..
 
-		let val = Composite::Named(vec![
-			("foo".to_string(), Value::u128(12345)),
-			("bar".to_string(), Value::char('c')),
-		]);
+		let val = Composite::named([("foo", Value::u128(12345)), ("bar", Value::char('c'))]);
 
 		assert_eq!(val.at("foo").unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at("bar").unwrap().as_char().unwrap(), 'c');
 
-		let val = Composite::Unnamed(vec![Value::u128(12345), Value::char('c')]);
+		let val = Composite::unnamed([Value::u128(12345), Value::char('c')]);
 
 		assert_eq!(val.at(0).unwrap().as_u128().unwrap(), 12345);
 		assert_eq!(val.at(1).unwrap().as_char().unwrap(), 'c');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,17 @@
     feature(32bit_target)
 )]
 
+mod at;
 mod scale_impls;
 #[cfg(feature = "serde")]
 mod serde_impls;
 mod string_impls;
 mod value;
 
+// Traits to allow indexing into values.
+pub use at::{At, Location};
+
+// The value definition.
 pub use value::{BitSequence, Composite, Primitive, Value, ValueDef, Variant};
 
 /// Serializing and deserializing a [`crate::Value`] into/from other types via serde.
@@ -56,9 +61,9 @@ pub mod serde {
 	/// use scale_value::Value;
 	///
 	/// let value = Value::unnamed_composite(vec![
-	///     Value::uint(1u8),
-	///     Value::uint(2u8),
-	///     Value::uint(3u8),
+	///     Value::u128(1),
+	///     Value::u128(2),
+	///     Value::u128(3),
 	/// ]);
 	///
 	/// let arr: [u8; 3] = scale_value::serde::from_value(value).unwrap();
@@ -76,15 +81,15 @@ pub mod serde {
 	///     B(u8, bool)
 	/// }
 	///
-	/// let value1 = Value::named_variant("A", vec![
-	///     ("name".into(), Value::string("James")),
-	///     ("is_valid".into(), Value::bool(true)),
+	/// let value1 = Value::named_variant("A", [
+	///     ("name", Value::string("James")),
+	///     ("is_valid", Value::bool(true)),
 	/// ]);
 	/// let foo1: Foo = scale_value::serde::from_value(value1).unwrap();
 	/// assert_eq!(foo1, Foo::A { is_valid: true, name: "James".into() });
 	///
-	/// let value2 = Value::unnamed_variant("B", vec![
-	///     Value::uint(123u8),
+	/// let value2 = Value::unnamed_variant("B", [
+	///     Value::u128(123),
 	///     Value::bool(true),
 	/// ]);
 	/// let foo2: Foo = scale_value::serde::from_value(value2).unwrap();
@@ -108,10 +113,10 @@ pub mod serde {
 	/// let arr = [1u8, 2u8, 3u8];
 	///
 	/// let val = scale_value::serde::to_value(arr).unwrap();
-	/// assert_eq!(val, Value::unnamed_composite(vec![
-	///     Value::uint(1u8),
-	///     Value::uint(2u8),
-	///     Value::uint(3u8),
+	/// assert_eq!(val, Value::unnamed_composite([
+	///     Value::u128(1),
+	///     Value::u128(2),
+	///     Value::u128(3),
 	/// ]));
 	/// ```
 	///
@@ -130,9 +135,9 @@ pub mod serde {
 	/// let foo = Foo::A { is_valid: true, name: "James".into() };
 	///
 	/// let value = scale_value::serde::to_value(foo).unwrap();
-	/// assert_eq!(value, Value::named_variant("A", vec![
-	///     ("is_valid".into(), Value::bool(true)),
-	///     ("name".into(), Value::string("James")),
+	/// assert_eq!(value, Value::named_variant("A", [
+	///     ("is_valid", Value::bool(true)),
+	///     ("name", Value::string("James")),
 	/// ]));
 	/// ```
 	pub fn to_value<T: serde::Serialize>(ty: T) -> Result<crate::Value<()>, SerializerError> {
@@ -166,9 +171,9 @@ pub mod serde {
 /// }
 ///
 /// // Given that, we can encode/decode something with that shape to/from SCALE bytes:
-/// let value = Value::named_variant("A", vec![
-///     ("is_valid".into(), Value::bool(true)),
-///     ("name".into(), Value::string("James")),
+/// let value = Value::named_variant("A", [
+///     ("is_valid", Value::bool(true)),
+///     ("name", Value::string("James")),
 /// ]);
 ///
 /// // Encode the Value to bytes:

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -190,17 +190,17 @@ fn decode_primitive_value(
 			Primitive::Char(char::from_u32(val).ok_or(DecodeError::InvalidChar(val))?)
 		}
 		TypeDefPrimitive::Str => Primitive::String(String::decode(data)?),
-		TypeDefPrimitive::U8 => Primitive::uint(u8::decode(data)?),
-		TypeDefPrimitive::U16 => Primitive::uint(u16::decode(data)?),
-		TypeDefPrimitive::U32 => Primitive::uint(u32::decode(data)?),
-		TypeDefPrimitive::U64 => Primitive::uint(u64::decode(data)?),
-		TypeDefPrimitive::U128 => Primitive::uint(u128::decode(data)?),
+		TypeDefPrimitive::U8 => Primitive::u128(u8::decode(data)? as u128),
+		TypeDefPrimitive::U16 => Primitive::u128(u16::decode(data)? as u128),
+		TypeDefPrimitive::U32 => Primitive::u128(u32::decode(data)? as u128),
+		TypeDefPrimitive::U64 => Primitive::u128(u64::decode(data)? as u128),
+		TypeDefPrimitive::U128 => Primitive::u128(u128::decode(data)?),
 		TypeDefPrimitive::U256 => Primitive::U256(<[u8; 32]>::decode(data)?),
-		TypeDefPrimitive::I8 => Primitive::int(i8::decode(data)?),
-		TypeDefPrimitive::I16 => Primitive::int(i16::decode(data)?),
-		TypeDefPrimitive::I32 => Primitive::int(i32::decode(data)?),
-		TypeDefPrimitive::I64 => Primitive::int(i64::decode(data)?),
-		TypeDefPrimitive::I128 => Primitive::int(i128::decode(data)?),
+		TypeDefPrimitive::I8 => Primitive::i128(i8::decode(data)? as i128),
+		TypeDefPrimitive::I16 => Primitive::i128(i16::decode(data)? as i128),
+		TypeDefPrimitive::I32 => Primitive::i128(i32::decode(data)? as i128),
+		TypeDefPrimitive::I64 => Primitive::i128(i64::decode(data)? as i128),
+		TypeDefPrimitive::I128 => Primitive::i128(i128::decode(data)? as i128),
 		TypeDefPrimitive::I256 => Primitive::I256(<[u8; 32]>::decode(data)?),
 	};
 	Ok(val)
@@ -220,19 +220,19 @@ fn decode_compact_value(
 		let val = match inner.type_def() {
 			// It's obvious how to decode basic primitive unsigned types, since we have impls for them.
 			TypeDef::Primitive(U8) => {
-				ValueDef::Primitive(Primitive::uint(Compact::<u8>::decode(data)?.0))
+				ValueDef::Primitive(Primitive::u128(Compact::<u8>::decode(data)?.0 as u128))
 			}
 			TypeDef::Primitive(U16) => {
-				ValueDef::Primitive(Primitive::uint(Compact::<u16>::decode(data)?.0))
+				ValueDef::Primitive(Primitive::u128(Compact::<u16>::decode(data)?.0 as u128))
 			}
 			TypeDef::Primitive(U32) => {
-				ValueDef::Primitive(Primitive::uint(Compact::<u32>::decode(data)?.0))
+				ValueDef::Primitive(Primitive::u128(Compact::<u32>::decode(data)?.0 as u128))
 			}
 			TypeDef::Primitive(U64) => {
-				ValueDef::Primitive(Primitive::uint(Compact::<u64>::decode(data)?.0))
+				ValueDef::Primitive(Primitive::u128(Compact::<u64>::decode(data)?.0 as u128))
 			}
 			TypeDef::Primitive(U128) => {
-				ValueDef::Primitive(Primitive::uint(Compact::<u128>::decode(data)?.0))
+				ValueDef::Primitive(Primitive::u128(Compact::<u128>::decode(data)?.0 as u128))
 			}
 			// A struct with exactly 1 field containing one of the above types can be sensibly compact encoded/decoded.
 			TypeDef::Composite(composite) => {
@@ -367,21 +367,21 @@ mod test {
 			"hello".to_string(), // String or &str (above) decode OK
 			Value::string("hello"),
 		);
-		encode_decode_check(123u8, Value::uint(123u8));
-		encode_decode_check(123u16, Value::uint(123u8));
-		encode_decode_check(123u32, Value::uint(123u8));
-		encode_decode_check(123u64, Value::uint(123u8));
-		encode_decode_check(123u128, Value::uint(123u8));
+		encode_decode_check(123u8, Value::u128(123));
+		encode_decode_check(123u16, Value::u128(123));
+		encode_decode_check(123u32, Value::u128(123));
+		encode_decode_check(123u64, Value::u128(123));
+		encode_decode_check(123u128, Value::u128(123));
 		//// Todo [jsdw]: Can we test this if we need a TypeInfo param?:
 		// encode_decode_check_explicit_info(
 		// 	[123u8; 32], // Anything 32 bytes long will do here
 		// 	Value::u256([123u8; 32]),
 		// );
-		encode_decode_check(123i8, Value::int(123i16));
-		encode_decode_check(123i16, Value::int(123i16));
-		encode_decode_check(123i32, Value::int(123i16));
-		encode_decode_check(123i64, Value::int(123i16));
-		encode_decode_check(123i128, Value::int(123i16));
+		encode_decode_check(123i8, Value::i128(123));
+		encode_decode_check(123i16, Value::i128(123));
+		encode_decode_check(123i32, Value::i128(123));
+		encode_decode_check(123i64, Value::i128(123));
+		encode_decode_check(123i128, Value::i128(123));
 		//// Todo [jsdw]: Can we test this if we need a TypeInfo param?:
 		// encode_decode_check_explicit_info(
 		// 	[123u8; 32], // Anything 32 bytes long will do here
@@ -391,11 +391,11 @@ mod test {
 
 	#[test]
 	fn decode_compact_primitives() {
-		encode_decode_check(Compact(123u8), Value::uint(123u8));
-		encode_decode_check(Compact(123u16), Value::uint(123u8));
-		encode_decode_check(Compact(123u32), Value::uint(123u8));
-		encode_decode_check(Compact(123u64), Value::uint(123u8));
-		encode_decode_check(Compact(123u128), Value::uint(123u8));
+		encode_decode_check(Compact(123u8), Value::u128(123));
+		encode_decode_check(Compact(123u16), Value::u128(123));
+		encode_decode_check(Compact(123u32), Value::u128(123));
+		encode_decode_check(Compact(123u64), Value::u128(123));
+		encode_decode_check(Compact(123u128), Value::u128(123));
 	}
 
 	#[test]
@@ -423,7 +423,7 @@ mod test {
 
 		encode_decode_check(
 			Compact(MyWrapper { inner: 123 }),
-			Value::named_composite(vec![("inner".to_string(), Value::uint(123u8))]),
+			Value::named_composite(vec![("inner".to_string(), Value::u128(123))]),
 		);
 	}
 
@@ -455,7 +455,7 @@ mod test {
 
 		encode_decode_check(
 			Compact(MyWrapper(123)),
-			Value::unnamed_composite(vec![Value::uint(123u8)]),
+			Value::unnamed_composite(vec![Value::u128(123)]),
 		);
 	}
 
@@ -463,19 +463,15 @@ mod test {
 	fn decode_sequence_array_tuple_types() {
 		encode_decode_check(
 			vec![1i32, 2, 3],
-			Value::unnamed_composite(vec![Value::int(1), Value::int(2), Value::int(3)]),
+			Value::unnamed_composite(vec![Value::i128(1), Value::i128(2), Value::i128(3)]),
 		);
 		encode_decode_check(
 			[1i32, 2, 3], // compile-time length known
-			Value::unnamed_composite(vec![Value::int(1), Value::int(2), Value::int(3)]),
+			Value::unnamed_composite(vec![Value::i128(1), Value::i128(2), Value::i128(3)]),
 		);
 		encode_decode_check(
 			(1i32, true, 123456u128),
-			Value::unnamed_composite(vec![
-				Value::int(1),
-				Value::bool(true),
-				Value::uint(123456u32),
-			]),
+			Value::unnamed_composite(vec![Value::i128(1), Value::bool(true), Value::u128(123456)]),
 		);
 	}
 
@@ -497,7 +493,7 @@ mod test {
 				"Bar",
 				vec![
 					("hi".to_string(), Value::string("hello".to_string())),
-					("other".to_string(), Value::uint(123u8)),
+					("other".to_string(), Value::u128(123)),
 				],
 			),
 		);
@@ -520,25 +516,17 @@ mod test {
 			Value::unnamed_composite(vec![
 				Value::bool(true),
 				Value::string("James".to_string()),
-				Value::unnamed_composite(vec![
-					Value::uint(1u8),
-					Value::uint(2u8),
-					Value::uint(3u8),
-				]),
+				Value::unnamed_composite(vec![Value::u128(1), Value::u128(2), Value::u128(3)]),
 			]),
 		);
 		encode_decode_check(
 			Named { is_valid: true, name: "James".into(), bytes: vec![1, 2, 3] },
 			Value::named_composite(vec![
-				("is_valid".into(), Value::bool(true)),
-				("name".into(), Value::string("James".to_string())),
+				("is_valid", Value::bool(true)),
+				("name", Value::string("James".to_string())),
 				(
-					"bytes".into(),
-					Value::unnamed_composite(vec![
-						Value::uint(1u8),
-						Value::uint(2u8),
-						Value::uint(3u8),
-					]),
+					"bytes",
+					Value::unnamed_composite(vec![Value::u128(1), Value::u128(2), Value::u128(3)]),
 				),
 			]),
 		);

--- a/src/serde_impls/deserializer.rs
+++ b/src/serde_impls/deserializer.rs
@@ -815,7 +815,7 @@ mod test {
 		let val = ValueDef::Composite(Composite::Named(vec![
 			// Order shouldn't matter; match on names:
 			("b".into(), Value::bool(true)),
-			("a".into(), Value::uint(123u8)),
+			("a".into(), Value::u128(123)),
 		]));
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -832,7 +832,7 @@ mod test {
 		let val = Composite::Named(vec![
 			// Order shouldn't matter; match on names:
 			("b".into(), Value::bool(true)),
-			("a".into(), Value::uint(123u8)),
+			("a".into(), Value::u128(123)),
 		]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -844,7 +844,7 @@ mod test {
 		struct Foo(u8, bool, String);
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::uint(123u8),
+			Value::u128(123),
 			Value::bool(true),
 			Value::string("hello"),
 		]));
@@ -858,7 +858,7 @@ mod test {
 		struct Foo(u8, bool, String);
 
 		let val =
-			Composite::Unnamed(vec![Value::uint(123u8), Value::bool(true), Value::string("hello")]);
+			Composite::Unnamed(vec![Value::u128(123), Value::bool(true), Value::string("hello")]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
 	}
@@ -875,9 +875,9 @@ mod test {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::uint(1u8),
-			Value::uint(2u8),
-			Value::uint(3u8),
+			Value::u128(1),
+			Value::u128(2),
+			Value::u128(3),
 		]));
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
@@ -889,7 +889,7 @@ mod test {
 		struct FooVar(MyEnum);
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![Value::uint(1u8), Value::uint(2u8), Value::uint(3u8)]),
+			values: Composite::Unnamed(vec![Value::u128(1), Value::u128(2), Value::u128(3)]),
 		});
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
 	}
@@ -903,7 +903,7 @@ mod test {
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
-		let val = Composite::Unnamed(vec![Value::uint(1u8), Value::uint(2u8), Value::uint(3u8)]);
+		let val = Composite::Unnamed(vec![Value::u128(1), Value::u128(2), Value::u128(3)]);
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
 		#[derive(Deserialize, Debug, PartialEq)]
@@ -914,7 +914,7 @@ mod test {
 		struct FooVar(MyEnum);
 		let val = Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![Value::uint(1u8), Value::uint(2u8), Value::uint(3u8)]),
+			values: Composite::Unnamed(vec![Value::u128(1), Value::u128(2), Value::u128(3)]),
 		};
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
 	}
@@ -922,9 +922,9 @@ mod test {
 	#[test]
 	fn de_into_vec() {
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::uint(1u8),
-			Value::uint(2u8),
-			Value::uint(3u8),
+			Value::u128(1),
+			Value::u128(2),
+			Value::u128(3),
 		]));
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
@@ -938,13 +938,13 @@ mod test {
 
 	#[test]
 	fn de_unwrapped_into_vec() {
-		let val = Composite::Unnamed(vec![Value::uint(1u8), Value::uint(2u8), Value::uint(3u8)]);
+		let val = Composite::Unnamed(vec![Value::u128(1), Value::u128(2), Value::u128(3)]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = Composite::Named(vec![
-			("a".into(), Value::uint(1u8)),
-			("b".into(), Value::uint(2u8)),
-			("c".into(), Value::uint(3u8)),
+			("a".into(), Value::u128(1)),
+			("b".into(), Value::u128(2)),
+			("c".into(), Value::u128(3)),
 		]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
@@ -958,9 +958,9 @@ mod test {
 		use std::collections::HashMap;
 
 		let val = ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::uint(1u8)),
-			("b".into(), Value::uint(2u8)),
-			("c".into(), Value::uint(3u8)),
+			("a".into(), Value::u128(1)),
+			("b".into(), Value::u128(2)),
+			("c".into(), Value::u128(3)),
 		]));
 		assert_eq!(
 			<HashMap<String, u8>>::deserialize(val),
@@ -968,9 +968,9 @@ mod test {
 		);
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::uint(1u8),
-			Value::uint(2u8),
-			Value::uint(3u8),
+			Value::u128(1),
+			Value::u128(2),
+			Value::u128(3),
 		]));
 		<HashMap<String, u8>>::deserialize(val).expect_err("no names; can't be map");
 	}
@@ -1000,7 +1000,7 @@ mod test {
 		// Enum variants with names values are allowed! The variant name will be ignored:
 		let val = ValueDef::Variant(Variant::named_fields(
 			"Foo",
-			vec![("a".into(), Value::string("hello")), ("b".into(), Value::bool(true))],
+			[("a", Value::string("hello")), ("b", Value::bool(true))],
 		));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
@@ -1008,7 +1008,7 @@ mod test {
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
 			Value::string("hello"),
 			Value::bool(true),
-			Value::uint(123u8),
+			Value::u128(123),
 		]));
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
@@ -1027,7 +1027,7 @@ mod test {
 
 		// Wrong number of values should fail:
 		let val =
-			Composite::Unnamed(vec![Value::string("hello"), Value::bool(true), Value::uint(123u8)]);
+			Composite::Unnamed(vec![Value::string("hello"), Value::bool(true), Value::u128(123)]);
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
 
@@ -1058,7 +1058,7 @@ mod test {
 			values: Composite::Unnamed(vec![
 				Value::string("hello"),
 				Value::bool(true),
-				Value::uint(123u8),
+				Value::u128(123),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1069,7 +1069,7 @@ mod test {
 			values: Composite::Named(vec![
 				("a".into(), Value::string("hello")),
 				("b".into(), Value::bool(true)),
-				("c".into(), Value::uint(123u8)),
+				("c".into(), Value::u128(123)),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1087,7 +1087,7 @@ mod test {
 			values: Composite::Unnamed(vec![
 				Value::string("hello"),
 				Value::bool(true),
-				Value::uint(123u8),
+				Value::u128(123),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1098,7 +1098,7 @@ mod test {
 			values: Composite::Named(vec![
 				("a".into(), Value::string("hello")),
 				("b".into(), Value::bool(true)),
-				("c".into(), Value::uint(123u8)),
+				("c".into(), Value::u128(123)),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1116,7 +1116,7 @@ mod test {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
 				// Deliberately out of order: names should ensure alignment:
-				("b".into(), Value::uint(123u8)),
+				("b".into(), Value::u128(123)),
 				("a".into(), Value::bool(true)),
 				("hi".into(), Value::string("hello")),
 			]),
@@ -1132,7 +1132,7 @@ mod test {
 			values: Composite::Unnamed(vec![
 				Value::string("hello"),
 				Value::bool(true),
-				Value::uint(123u8),
+				Value::u128(123),
 			]),
 		});
 		assert_eq!(
@@ -1145,7 +1145,7 @@ mod test {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
 				Value::bool(true),
-				Value::uint(123u8),
+				Value::u128(123),
 				Value::string("hello"),
 			]),
 		});
@@ -1155,7 +1155,7 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("b".into(), Value::uint(123u8)),
+				("b".into(), Value::u128(123)),
 				// Whoops; wrong name:
 				("c".into(), Value::bool(true)),
 				("hi".into(), Value::string("hello")),
@@ -1167,8 +1167,8 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("foo".into(), Value::uint(40u8)),
-				("b".into(), Value::uint(123u8)),
+				("foo".into(), Value::u128(40)),
+				("b".into(), Value::u128(123)),
 				("a".into(), Value::bool(true)),
 				("bar".into(), Value::bool(false)),
 				("hi".into(), Value::string("hello")),

--- a/src/serde_impls/serialize.rs
+++ b/src/serde_impls/serialize.rs
@@ -144,7 +144,7 @@ mod test {
 	#[test]
 	fn serialize_primitives() {
 		// a subset of the primitives to sanity check that they are unwrapped:
-		assert_value(Value::uint(1u8), json!(1));
+		assert_value(Value::u128(1), json!(1));
 		assert_value(Value::bool(true), json!(true));
 		assert_value(Value::bool(false), json!(false));
 	}
@@ -152,10 +152,10 @@ mod test {
 	#[test]
 	fn serialize_composites() {
 		assert_value(
-			Value::named_composite(vec![
-				("a".into(), Value::bool(true)),
-				("b".into(), Value::string("hello")),
-				("c".into(), Value::char('c')),
+			Value::named_composite([
+				("a", Value::bool(true)),
+				("b", Value::string("hello")),
+				("c", Value::char('c')),
 			]),
 			json!({
 				"a": true,
@@ -164,11 +164,7 @@ mod test {
 			}),
 		);
 		assert_value(
-			Value::unnamed_composite(vec![
-				Value::bool(true),
-				Value::string("hello"),
-				Value::char('c'),
-			]),
+			Value::unnamed_composite([Value::bool(true), Value::string("hello"), Value::char('c')]),
 			json!([true, "hello", 'c']),
 		)
 	}

--- a/src/string_impls/from_string.rs
+++ b/src/string_impls/from_string.rs
@@ -357,12 +357,12 @@ fn parse_number(t: &mut impl Tokens<Item = char>) -> Result<Primitive, Option<Pa
 	if is_positive {
 		n_str
 			.parse::<u128>()
-			.map(Primitive::uint)
+			.map(Primitive::u128)
 			.map_err(|e| Some(ParseNumberError::ParsingFailed(e).between(start_loc, end_loc)))
 	} else {
 		n_str
 			.parse::<i128>()
-			.map(Primitive::int)
+			.map(Primitive::i128)
 			.map_err(|e| Some(ParseNumberError::ParsingFailed(e).between(start_loc, end_loc)))
 	}
 }
@@ -518,10 +518,10 @@ mod test {
 
 	#[test]
 	fn parse_numbers() {
-		assert_eq!(from("123"), Ok(Value::uint(123u128)));
-		assert_eq!(from("1_234_56"), Ok(Value::uint(123_456_u128)));
-		assert_eq!(from("+1_234_56"), Ok(Value::uint(123_456_u128)));
-		assert_eq!(from("-123_4"), Ok(Value::int(-1234)));
+		assert_eq!(from("123"), Ok(Value::u128(123)));
+		assert_eq!(from("1_234_56"), Ok(Value::u128(123_456)));
+		assert_eq!(from("+1_234_56"), Ok(Value::u128(123_456)));
+		assert_eq!(from("-123_4"), Ok(Value::i128(-1234)));
 		assert_eq!(from("-abc"), Err(ParseNumberError::ExpectedDigit.between(1, 2)));
 	}
 
@@ -558,12 +558,12 @@ mod test {
 			from("(  true, 1234 ,\t\n\t \"Hello!\" )"),
 			Ok(Value::unnamed_composite(vec![
 				Value::bool(true),
-				Value::uint(1234u128),
+				Value::u128(1234),
 				Value::string("Hello!")
 			]))
 		);
-		assert_eq!(from("()"), Ok(Value::unnamed_composite(vec![])));
-		assert_eq!(from("(\n\n\t\t\n)"), Ok(Value::unnamed_composite(vec![])));
+		assert_eq!(from("()"), Ok(Value::unnamed_composite([])));
+		assert_eq!(from("(\n\n\t\t\n)"), Ok(Value::unnamed_composite([])));
 	}
 
 	#[test]
@@ -576,10 +576,10 @@ mod test {
             \"Hello there 😀\": \"Hello!\"
         }"
 			),
-			Ok(Value::named_composite(vec![
-				("hello".into(), Value::bool(true)),
-				("foo".into(), Value::uint(1234u128)),
-				("Hello there 😀".into(), Value::string("Hello!"))
+			Ok(Value::named_composite([
+				("hello", Value::bool(true)),
+				("foo", Value::u128(1234)),
+				("Hello there 😀", Value::string("Hello!"))
 			]))
 		);
 	}
@@ -596,10 +596,10 @@ mod test {
 			),
 			Ok(Value::named_variant(
 				"MyVariant",
-				vec![
-					("hello".into(), Value::bool(true)),
-					("foo".into(), Value::uint(1234u128)),
-					("Hello there 😀".into(), Value::string("Hello!"))
+				[
+					("hello", Value::bool(true)),
+					("foo", Value::u128(1234)),
+					("Hello there 😀", Value::string("Hello!"))
 				]
 			))
 		);
@@ -608,19 +608,19 @@ mod test {
 			from("Foo (  true, 1234 ,\t\n\t \"Hello!\" )"),
 			Ok(Value::unnamed_variant(
 				"Foo",
-				vec![Value::bool(true), Value::uint(1234u128), Value::string("Hello!")]
+				vec![Value::bool(true), Value::u128(1234), Value::string("Hello!")]
 			))
 		);
 
-		assert_eq!(from("Foo()"), Ok(Value::unnamed_variant("Foo", vec![])));
-		assert_eq!(from("Foo{}"), Ok(Value::named_variant("Foo", vec![])));
-		assert_eq!(from("Foo( \t)"), Ok(Value::unnamed_variant("Foo", vec![])));
-		assert_eq!(from("Foo{  }"), Ok(Value::named_variant("Foo", vec![])));
+		assert_eq!(from("Foo()"), Ok(Value::unnamed_variant("Foo", [])));
+		assert_eq!(from("Foo{}"), Ok(Value::named_variant::<_, String, _>("Foo", [])));
+		assert_eq!(from("Foo( \t)"), Ok(Value::unnamed_variant("Foo", [])));
+		assert_eq!(from("Foo{  }"), Ok(Value::named_variant::<_, String, _>("Foo", [])));
 
 		// Parsing special "v" strings:
 		assert_eq!(
 			from("v\"variant name\" {  }"),
-			Ok(Value::named_variant("variant name", vec![]))
+			Ok(Value::named_variant::<_, String, _>("variant name", []))
 		);
 	}
 

--- a/src/string_impls/to_string.rs
+++ b/src/string_impls/to_string.rs
@@ -181,9 +181,9 @@ mod test {
 		assert_from_to(Value::char('\0'));
 		assert_from_to(Value::char('\t'));
 
-		assert_from_to(Value::int(-123_456));
-		assert_from_to(Value::uint(0u128));
-		assert_from_to(Value::uint(123456u128));
+		assert_from_to(Value::i128(-123_456));
+		assert_from_to(Value::u128(0));
+		assert_from_to(Value::u128(123456));
 
 		assert_from_to(Value::string("hello \"you\",\n\n\t How are you??"));
 		assert_from_to(Value::string(""));
@@ -191,13 +191,13 @@ mod test {
 
 	#[test]
 	fn composites() {
-		assert_from_to(Value::named_composite(vec![
-			("foo".into(), Value::uint(12345u128)),
-			("bar".into(), Value::bool(true)),
-			("a \"weird\" name".into(), Value::string("Woop!")),
+		assert_from_to(Value::named_composite([
+			("foo", Value::u128(12345)),
+			("bar", Value::bool(true)),
+			("a \"weird\" name", Value::string("Woop!")),
 		]));
-		assert_from_to(Value::unnamed_composite(vec![
-			Value::uint(12345u128),
+		assert_from_to(Value::unnamed_composite([
+			Value::u128(12345),
 			Value::bool(true),
 			Value::string("Woop!"),
 		]));
@@ -207,15 +207,15 @@ mod test {
 	fn variants() {
 		assert_from_to(Value::named_variant(
 			"A weird variant name",
-			vec![
-				("foo".into(), Value::uint(12345u128)),
-				("bar".into(), Value::bool(true)),
-				("a \"weird\" name".into(), Value::string("Woop!")),
+			[
+				("foo", Value::u128(12345)),
+				("bar", Value::bool(true)),
+				("a \"weird\" name", Value::string("Woop!")),
 			],
 		));
 		assert_from_to(Value::unnamed_variant(
 			"MyVariant",
-			vec![Value::uint(12345u128), Value::bool(true), Value::string("Woop!")],
+			[Value::u128(12345), Value::bool(true), Value::string("Woop!")],
 		));
 	}
 


### PR DESCRIPTION
The main addition here is allowing indexing into Values using an `.at()` function (because alas the built-in Index trait wasn't suitable; we need to be able to return a non-referential type that could be `None` if no value was found (serde_json::Value gets around this by declaring a static Null value to hand back, but we can't do this as we have a generic context that can be attached to each value).

I've also make some of the constructors more generic to cut down on general noise/clutter, and added some methods to cast values into primitive types to make it easier to indexinto and then pull out a primitive value that you expect at some location.