### PR TITLE
Add hex and ss58 custom parsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,9 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [features]
 default = ["serde", "from_string"]
 # Enable support for parsing strings into Values.
-from_string = [
-    "dep:yap"
-]
+from_string = ["dep:yap"]
 # Enable serde support for serializing/deserializing Values.
-serde = [
-    "dep:serde",
-    "scale-bits/serde",
-]
+serde = ["dep:serde", "scale-bits/serde"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
@@ -38,4 +33,5 @@ either = "1.6.1"
 yap = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
+hex = "0.4.3"
 serde_json = "1.0.64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ keywords = ["parity", "scale", "encoding", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [features]
-default = ["serde", "from_string"]
+default = ["serde", "from_string", "parser-ss58"]
 # Enable support for parsing strings into Values.
 from_string = ["dep:yap"]
 # Enable serde support for serializing/deserializing Values.
 serde = ["dep:serde", "scale-bits/serde"]
+# Provide an ss58 address parser
+parser-ss58 = ["dep:base58", "dep:blake2"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
@@ -31,6 +33,8 @@ scale-encode = { version = "0.1.0", default-features = false, features = ["bits"
 scale-bits = "0.3.0"
 either = "1.6.1"
 yap = { version = "0.10.0", optional = true }
+base58 = { version = "0.2.0", optional = true }
+blake2 = { version = "0.10.6", optional = true, default_features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ from_string = ["dep:yap"]
 # Enable serde support for serializing/deserializing Values.
 serde = ["dep:serde", "scale-bits/serde"]
 # Provide an ss58 address parser
-parser-ss58 = ["dep:base58", "dep:blake2"]
+parser-ss58 = ["dep:base58", "dep:blake2", "from_string"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }

--- a/FILE_TEMPLATE
+++ b/FILE_TEMPLATE
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/at.rs
+++ b/src/at.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,11 @@ pub mod stringify {
     /// This module provides custom parsers that work alongside [`crate::stringify::from_str_custom`]
     /// and extend the syntax to support parsing common formats into [`crate::Value`]'s. See
     /// [`crate::stringify::from_str_custom`] for a usage example.
+    #[cfg(feature = "from_string")]
     pub mod custom_parsers {
-        pub use crate::string_impls::{parse_hex, parse_ss58, ParseHexError};
+        #[cfg(feature = "parser-ss58")]
+        pub use crate::string_impls::parse_ss58;
+        pub use crate::string_impls::{parse_hex, ParseHexError};
     }
 
     /// Attempt to parse a string into a [`crate::Value<()>`], returning a tuple

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,17 @@ pub mod scale {
 /// Converting a [`crate::Value`] to or from strings.
 pub mod stringify {
     #[cfg(feature = "from_string")]
-    pub use crate::string_impls::{FromStrBuilder, ParseError};
+    pub use crate::string_impls::{
+        FromStrBuilder,
+        ParseError,
+        ParseErrorKind,
+        ParseBitSequenceError,
+        ParseCharError,
+        ParseComplexError,
+        ParseCustomError,
+        ParseNumberError,
+        ParseStringError,
+    };
 
     /// Attempt to parse a string into a [`crate::Value<()>`], returning a tuple
     /// consisting of a result (either the value or a [`ParseError`] containing

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/bitvec_helpers.rs
+++ b/src/serde_impls/bitvec_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/deserialize.rs
+++ b/src/serde_impls/deserialize.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/deserializer.rs
+++ b/src/serde_impls/deserializer.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/mod.rs
+++ b/src/serde_impls/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/serialize.rs
+++ b/src/serde_impls/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/serde_impls/serializer.rs
+++ b/src/serde_impls/serializer.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/string_impls/custom_parsers/hex.rs
+++ b/src/string_impls/custom_parsers/hex.rs
@@ -55,7 +55,7 @@ pub fn parse_hex(s: &mut &str) -> Option<Result<Value<()>, ParseError>> {
             .contains(b)
             .then(|| b - b'a' + 10)
             .or_else(|| (b'A'..=b'F').contains(b).then(|| b - b'A' + 10))
-            .or_else(|| (b'0'..=b'9').contains(b).then(|| b - b'0'));
+            .or_else(|| b.is_ascii_digit().then(|| b - b'0'));
 
         let Some(hex_nibble) = hex_nibble else {
             return Some(Err(ParseErrorKind::custom(ParseHexError::InvalidChar(*b as char)).at(idx)))

--- a/src/string_impls/custom_parsers/hex.rs
+++ b/src/string_impls/custom_parsers/hex.rs
@@ -1,0 +1,196 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the scale-value crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{ Value, stringify::{ ParseErrorKind, ParseError } };
+
+/// Attempt to parse a hex string into a [`Value<()>`] (or more specifically,
+/// an unnamed composite).
+///
+/// - Returns an error if we see a leading `0x` and then see invalid hex
+///   characters after this.
+/// - Returns `None` if no `0x` is seen first.
+/// - Returns `Some(value)` if parsing was successful. In this case, the string
+///   reference given is wound forwards to consume what was parsed.
+pub fn parse_hex(s: &mut &str) -> Option<Result<Value<()>, ParseError>> {
+    let bytes = s.as_bytes();
+
+    // Look for leading "0x"; None if this obviously isn't hex.
+    if bytes[0] != b'0' || bytes[1] != b'x' {
+        return None;
+    }
+
+    let mut composite_values = vec![];
+
+    // find all valid hex chars after 0x:
+    let mut idx = 2;
+    let mut last_nibble = None;
+    loop {
+        // Break if we hit end of string.
+        let Some(b) = bytes.get(idx) else {
+            break;
+        };
+
+        // Break as soon as we hit some non-alphanumeric char.
+        if !b.is_ascii_alphanumeric() {
+            break
+        }
+
+        // 4 bit number from hex char
+        let hex_nibble= (b'a' ..= b'f').contains(b).then(|| b - b'a' + 10)
+            .or_else(|| (b'A' ..= b'F').contains(b).then(|| b - b'A' + 10))
+            .or_else(|| (b'0' ..= b'9').contains(b).then(|| b - b'0'));
+
+        let Some(hex_nibble) = hex_nibble else {
+            return Some(Err(ParseErrorKind::custom(ParseHexError::InvalidChar(*b as char)).at(idx)))
+        };
+
+        match last_nibble {
+            None => {
+                // The first of 2 chars; keep hold of:
+                last_nibble = Some(hex_nibble)
+            },
+            Some(n) => {
+                // The second; combine and push byte to output:
+                let byte = n * 16 + hex_nibble;
+                composite_values.push(Value::u128(byte as u128));
+                last_nibble = None;
+            }
+        }
+
+        idx += 1;
+    }
+
+    // We have leftovers; wrong length!
+    if last_nibble.is_some() {
+        return Some(Err(ParseErrorKind::custom(ParseHexError::WrongLength).between(0, idx)))
+    }
+
+    // Consume the "used" up bytes and return our Value.
+    //
+    // # Unsafety
+    //
+    // We have consumed only ASCII chars to get this far, so
+    // we know the bytes following make up a valid str.
+    *s = unsafe { std::str::from_utf8_unchecked(&bytes[idx..]) };
+    Some(Ok(Value::unnamed_composite(composite_values)))
+}
+
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ParseHexError {
+    #[error("Invalid hex character: {0}")]
+    InvalidChar(char),
+    #[error("Hex string is the wrong length; should be an even length")]
+    WrongLength
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parses_same_as_hex_crate() {
+        let expects = [
+            "0x",
+            "0x00",
+            "0x000102030405060708090A0B",
+            "0xDEADBEEF",
+            "0x00BAB10C",
+        ];
+
+        for input in expects {
+            let expected_hex = hex::decode(input.trim_start_matches("0x")).expect("valid hex");
+            let cursor = &mut &*input;
+            let hex = parse_hex(cursor).expect("valid hex expected").expect("no error expected");
+
+            assert_eq!(
+                hex,
+                Value::from_bytes(expected_hex),
+                "values should match"
+            );
+        }
+    }
+
+    #[test]
+    fn consumes_parsed_hex() {
+        let expects = [
+            ("0x foo", " foo"),
+            ("0x00,bar", ",bar"),
+            ("0x123456-2", "-2"),
+            ("0xDEADBEEF ", " "),
+        ];
+
+        for (input, expected_remaining) in expects {
+            let cursor = &mut &*input;
+            let _ = parse_hex(cursor).expect("valid hex expected").expect("no error expected");
+
+            assert_eq!(*cursor, expected_remaining);
+        }
+    }
+
+    #[test]
+    fn err_wrong_length() {
+        let expects = [
+            "0x1",
+            "0x123",
+        ];
+
+        for input in expects {
+            let cursor = &mut &*input;
+            let err = parse_hex(cursor)
+                .expect("some result expected")
+                .expect_err("an error is expected");
+
+            assert_eq!(err.start_loc, 0);
+            assert_eq!(err.end_loc, Some(input.len()));
+
+            let ParseErrorKind::Custom(err) = err.err else {
+                panic!("expected custom error")
+            };
+
+            let concrete_err: Box<ParseHexError> = err.downcast().unwrap();
+            assert_eq!(&*concrete_err, &ParseHexError::WrongLength);
+            assert_eq!(input, *cursor);
+        }
+    }
+
+    #[test]
+    fn err_invalid_char() {
+        let expects = [
+            ("0x12345x", 'x', 7),
+            ("0x123h4", 'h', 5),
+            ("0xG23h4", 'G', 2),
+        ];
+
+        for (input, bad_char, pos) in expects {
+            let cursor = &mut &*input;
+            let err = parse_hex(cursor)
+                .expect("some result expected")
+                .expect_err("an error is expected");
+
+            assert_eq!(err.start_loc, pos);
+            assert!(err.end_loc.is_none());
+
+            let ParseErrorKind::Custom(err) = err.err else {
+                panic!("expected custom error")
+            };
+
+            let concrete_err: Box<ParseHexError> = err.downcast().unwrap();
+            assert_eq!(&*concrete_err, &ParseHexError::InvalidChar(bad_char));
+            assert_eq!(input, *cursor);
+        }
+    }
+
+}

--- a/src/string_impls/custom_parsers/hex.rs
+++ b/src/string_impls/custom_parsers/hex.rs
@@ -29,6 +29,11 @@ use crate::{
 pub fn parse_hex(s: &mut &str) -> Option<Result<Value<()>, ParseError>> {
     let bytes = s.as_bytes();
 
+    // Need at least 2 bytes for 0x
+    if bytes.len() < 2 {
+        return None;
+    }
+
     // Look for leading "0x"; None if this obviously isn't hex.
     if bytes[0] != b'0' || bytes[1] != b'x' {
         return None;
@@ -173,5 +178,11 @@ mod test {
             assert_eq!(&*concrete_err, &ParseHexError::InvalidChar(bad_char));
             assert_eq!(input, *cursor);
         }
+    }
+
+    #[test]
+    fn empty_string_doesnt_panic() {
+        assert!(parse_hex(&mut "").is_none());
+        assert!(parse_hex(&mut "0").is_none());
     }
 }

--- a/src/string_impls/custom_parsers/mod.rs
+++ b/src/string_impls/custom_parsers/mod.rs
@@ -14,7 +14,11 @@
 // limitations under the License.
 
 mod hex;
+
+#[cfg(feature = "parser-ss58")]
 mod ss58;
 
 pub use self::hex::{parse_hex, ParseHexError};
+
+#[cfg(feature = "parser-ss58")]
 pub use ss58::parse_ss58;

--- a/src/string_impls/custom_parsers/mod.rs
+++ b/src/string_impls/custom_parsers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,5 +14,7 @@
 // limitations under the License.
 
 mod hex;
+mod ss58;
 
-pub use self::hex::{ parse_hex, ParseHexError };
+pub use self::hex::{parse_hex, ParseHexError};
+pub use ss58::parse_ss58;

--- a/src/string_impls/custom_parsers/mod.rs
+++ b/src/string_impls/custom_parsers/mod.rs
@@ -13,23 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "from_string")]
-mod from_string;
-#[cfg(feature = "from_string")]
-mod custom_parsers;
+mod hex;
 
-mod string_helpers;
-mod to_string;
-
-#[cfg(feature = "from_string")]
-pub use from_string::{
-    FromStrBuilder,
-    ParseError,
-    ParseErrorKind,
-    ParseBitSequenceError,
-    ParseCharError,
-    ParseComplexError,
-    ParseCustomError,
-    ParseNumberError,
-    ParseStringError,
-};
+pub use self::hex::{ parse_hex, ParseHexError };

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -44,14 +44,14 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
     // This is mostly an optimisation but also eliminates some potential weird edge cases.
     if maybe_ss58 == "true"
         || maybe_ss58 == "false"
-        || maybe_ss58.find(|c: char| c.is_ascii_alphabetic()).is_none()
+        || maybe_ss58.chars().all(|c: char| c.is_ascii_digit())
     {
         return None;
     }
 
-    // Before going any further, if this is a variant ident, a `{` or `(` will follow
-    // (eg `Foo { hi: 1 }` or `Foo (1)`. In this case, don't try to parse as an ss58
-    // address, since it would definitely be wrong.
+    // If what we are parsing is a variant ident, a `{` or `(` will follow
+    // (eg `Foo { hi: 1 }` or `Foo (1)`). In this case, don't try to parse
+    // as an ss58 address, since it would definitely be wrong to do so.
     if rest.trim_start().starts_with(|c| c == '(' || c == '{') {
         return None;
     }
@@ -62,14 +62,10 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
         return None
     };
 
-    if bytes.is_empty() {
-        return None;
-    }
-
     // decode length of address prefix.
-    let prefix_len = match bytes[0] {
-        0..=63 => 1,
-        64..=127 => 2,
+    let prefix_len = match bytes.get(0) {
+        Some(0..=63) => 1,
+        Some(64..=127) => 2,
         _ => return None,
     };
 

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -63,7 +63,7 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
     };
 
     // decode length of address prefix.
-    let prefix_len = match bytes.get(0) {
+    let prefix_len = match bytes.first() {
         Some(0..=63) => 1,
         Some(64..=127) => 2,
         _ => return None,

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -75,7 +75,7 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
     // Everything checks out; wind the string cursor forwards and
     // return the bytes representing the address provided.
     *s = rest;
-    return Some(bytes[prefix_len..checksum_start_idx].to_vec());
+    Some(bytes[prefix_len..checksum_start_idx].to_vec())
 }
 
 fn ss58hash(data: &[u8]) -> Vec<u8> {

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -1,0 +1,134 @@
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the scale-value crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{stringify::ParseError, Value};
+
+/// Attempt to parse an ss58 address into a [`Value<()>`] (or more specifically,
+/// an unnamed composite wrapped in a newtype which represents an AccountId32).
+///
+/// - Returns `None` if we can't parse the address.
+/// - Returns `Some(value)` if parsing was successful. In this case, the string
+///   reference given is wound forwards to consume what was parsed.
+pub fn parse_ss58(s: &mut &str) -> Option<Result<Value<()>, ParseError>> {
+    let bytes = parse_ss58_bytes(s)?;
+    Some(Ok(Value::from_bytes(bytes)))
+}
+
+fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
+    const CHECKSUM_LEN: usize = 2;
+
+    // ss58 addresses are base58 encoded. Base58 is all alphanumeric chars
+    // minus a few that look potentially similar. So, gather alphanumeric chars
+    // first.
+    let end_idx = s.find(|c: char| !c.is_alphanumeric()).unwrap_or(s.len());
+    let maybe_ss58 = &s[0..end_idx];
+    let rest = &s[end_idx..];
+
+    if maybe_ss58.is_empty() {
+        return None;
+    }
+
+    // Attempt to base58-decode these chars.
+    use base58::FromBase58;
+    let Ok(bytes) = maybe_ss58.from_base58() else {
+        return None
+    };
+
+    if bytes.is_empty() {
+        return None;
+    }
+
+    // decode length of address prefix.
+    let prefix_len = match bytes[0] {
+        0..=63 => 1,
+        64..=127 => 2,
+        _ => return None,
+    };
+
+    if bytes.len() < prefix_len + CHECKSUM_LEN {
+        return None;
+    }
+
+    // The checksum is the last 2 bytes:
+    let checksum_start_idx = bytes.len() - CHECKSUM_LEN;
+
+    // Check that the checksum lines up with the rest of the address; if not,
+    // this isn't a valid address.
+    let hash = ss58hash(&bytes[0..checksum_start_idx]);
+    let checksum = &hash[0..CHECKSUM_LEN];
+    if &bytes[checksum_start_idx..] != checksum {
+        return None;
+    }
+
+    // Everything checks out; wind the string cursor forwards and
+    // return the bytes representing the address provided.
+    *s = rest;
+    return Some(bytes[prefix_len..checksum_start_idx].to_vec());
+}
+
+fn ss58hash(data: &[u8]) -> Vec<u8> {
+    use blake2::{Blake2b512, Digest};
+    const PREFIX: &[u8] = b"SS58PRE";
+    let mut ctx = Blake2b512::new();
+    ctx.update(PREFIX);
+    ctx.update(data);
+    ctx.finalize().to_vec()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn can_parse_ss58_address() {
+        // hex keys obtained via `subkey`, so we're comparing our decoding against that.
+        // We simultaneously check that things after the address aren't consumed.
+        let expected = [
+            // Alice
+            (
+                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY ",
+                "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+                " ",
+            ),
+            // Bob
+            (
+                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty-100",
+                "8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
+                "-100",
+            ),
+            // Charlie
+            (
+                "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,1,2,3",
+                "90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22",
+                ",1,2,3",
+            ),
+            // Eve
+            (
+                "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw }",
+                "e659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e",
+                " }",
+            ),
+        ];
+
+        for (ss58, expected_hex, expected_remaining) in expected {
+            let cursor = &mut &*ss58;
+            let bytes = parse_ss58_bytes(cursor).expect("address should parse OK");
+            let expected = hex::decode(expected_hex).expect("hex should decode OK");
+
+            assert_eq!(bytes, expected);
+            assert_eq!(*cursor, expected_remaining);
+        }
+    }
+}

--- a/src/string_impls/from_string.rs
+++ b/src/string_impls/from_string.rs
@@ -119,6 +119,7 @@ macro_rules! at_between {
 
 /// Details about the error that occurred.
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseErrorKind {
     #[error("Expected a value")]
     ExpectedValue,
@@ -133,21 +134,22 @@ pub enum ParseErrorKind {
     #[error("{0}")]
     BitSequence(#[from] ParseBitSequenceError),
     #[error("{0}")]
-    Custom(CustomError),
+    Custom(ParseCustomError),
 }
 at_between!(ParseErrorKind);
 
 impl ParseErrorKind {
     /// Construct a custom error.
-    pub fn custom<E: Into<CustomError>>(e: E) -> Self {
+    pub fn custom<E: Into<ParseCustomError>>(e: E) -> Self {
         ParseErrorKind::Custom(e.into())
     }
 }
 
 /// An arbitrary custom error.
-pub type CustomError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type ParseCustomError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseComplexError {
     #[error("The first character in a field name should be alphabetic")]
     InvalidStartingCharacterInIdent,
@@ -161,6 +163,7 @@ pub enum ParseComplexError {
 at_between!(ParseComplexError);
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseCharError {
     #[error("Expected a single character")]
     ExpectedValidCharacter,
@@ -172,6 +175,7 @@ pub enum ParseCharError {
 at_between!(ParseCharError);
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseStringError {
     #[error("Expected a closing quote to match the opening quote at position {0}")]
     ExpectedClosingQuoteToMatch(usize),
@@ -181,6 +185,7 @@ pub enum ParseStringError {
 at_between!(ParseStringError);
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseNumberError {
     #[error("Expected one or more digits")]
     ExpectedDigit,
@@ -190,6 +195,7 @@ pub enum ParseNumberError {
 at_between!(ParseNumberError);
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseBitSequenceError {
     #[error("Expected a closing bracket ('>') to match the opening one at position {0}")]
     ExpectedClosingBracketToMatch(usize),

--- a/src/string_impls/from_string.rs
+++ b/src/string_impls/from_string.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/string_impls/mod.rs
+++ b/src/string_impls/mod.rs
@@ -27,5 +27,7 @@ pub use from_string::{
     ParseError, ParseErrorKind, ParseNumberError, ParseStringError,
 };
 
+#[cfg(feature = "parser-ss58")]
+pub use custom_parsers::parse_ss58;
 #[cfg(feature = "from_string")]
-pub use custom_parsers::{parse_hex, parse_ss58, ParseHexError};
+pub use custom_parsers::{parse_hex, ParseHexError};

--- a/src/string_impls/mod.rs
+++ b/src/string_impls/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,22 +14,18 @@
 // limitations under the License.
 
 #[cfg(feature = "from_string")]
-mod from_string;
-#[cfg(feature = "from_string")]
 mod custom_parsers;
+#[cfg(feature = "from_string")]
+mod from_string;
 
 mod string_helpers;
 mod to_string;
 
 #[cfg(feature = "from_string")]
 pub use from_string::{
-    FromStrBuilder,
-    ParseError,
-    ParseErrorKind,
-    ParseBitSequenceError,
-    ParseCharError,
-    ParseComplexError,
-    ParseCustomError,
-    ParseNumberError,
-    ParseStringError,
+    FromStrBuilder, ParseBitSequenceError, ParseCharError, ParseComplexError, ParseCustomError,
+    ParseError, ParseErrorKind, ParseNumberError, ParseStringError,
 };
+
+#[cfg(feature = "from_string")]
+pub use custom_parsers::{parse_hex, parse_ss58, ParseHexError};

--- a/src/string_impls/string_helpers.rs
+++ b/src/string_impls/string_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/string_impls/to_string.rs
+++ b/src/string_impls/to_string.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Parity Technologies (UK) Ltd. (admin@parity.io)
+// Copyright (C) 2022-2023 Parity Technologies (UK) Ltd. (admin@parity.io)
 // This file is a part of the scale-value crate.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
These parsers are available via `scale_value::stringify::custom_parsers` and allow hex and ss58 addresses to be correctly parsed as part of a string Value.