### PR TITLE
encode: Encode nested tuples properly

### DIFF
--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -192,11 +192,11 @@ fn maybe_encode_nested_sequences<T>(
     match &seq_ty.type_def {
         TypeDef::Tuple(_) | TypeDef::Composite(_) => {
             // Inspect the values as is, because `find_sequence_candidate` will recurse.
-            let mut values = value.values();
+            let values = value.values();
 
             // Encode the length of the sequence first.
             Compact(values.len() as u32).encode_to(out);
-            while let Some(value) = values.next() {
+            for value in values {
                 match value {
                     Value { value: ValueDef::Composite(inner_composite), .. } => {
                         if let Err(err) = encode_composite(inner_composite, id, types, out) {


### PR DESCRIPTION
This PR ensures that nested tuples inside sequences can be encoded properly.

Prior to this encoding a `Vec<(u8, u16)>` would not work properly with dynamic values of

```rust
Value::unnamed_composite(
        vec![
            Value::u128(3u8.into()),
            Value::u128(1u16.into()),
        ]
    );
```

This is because `find_sequence_candidate` function did assume that the last type of the value is the "end-type" of the sequence.

Instead, if we deal with tuple/composite inside a sequence (sequence or array otherwise), then recurse back to `encode_composite` with proper parameters (unflattened).

Detected by: https://github.com/paritytech/subxt/issues/982.    


// @paritytech/subxt-team 

