### PR TITLE
Bump scale-encode and scale-decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.12.0 (28-07-2023)
+
+- Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively).
+
 ## 0.11.0 (18-07-2023)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## 0.12.0 (28-07-2023)
+## 0.12.0 (2023-08-02)
 
-- Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively).
+- Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively). One effect that this has is that structs
+  containing compact encoded values, after being encoded, now decode to composite types and not directly to the underlying compact
+  encoded values. This should better mirror the original type.
 
-## 0.11.0 (18-07-2023)
+## 0.11.0 (2023-07-18)
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## 0.12.0 (2023-08-02)
 
-- Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively). One effect that this has is that structs
-  containing compact encoded values, after being encoded, now decode to composite types and not directly to the underlying compact
-  encoded values. This should better mirror the original type.
+Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively).
+
+One effect that this has is that structs containing compact encoded values, after being encoded, now decode to composite types that better
+reflect their original shape. For example, `Compact(MyWrapper { inner: 123 })`, when encoded, used to decode to `Value::u128(123)`,
+but now it decodes to `Value::named_composite(vec![("inner", Value::u128(123))]).`
 
 ## 0.11.0 (2023-07-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ derive_more = { version = "0.99.17", default-features = false, features = ["disp
 [dev-dependencies]
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-scale-decode = { version = "0.8.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.9.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -41,8 +41,8 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
 frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 scale-info = { version = "2.5.0", default-features = false }
-scale-decode = { version = "0.8.0", default-features = false }
-scale-encode = { version = "0.4.0", default-features = false, features = ["bits"] }
+scale-decode = { version = "0.9.0", default-features = false }
+scale-encode = { version = "0.5.0", default-features = false, features = ["bits"] }
 scale-bits = { version = "0.4.0", default-features = false, features = ["serde", "scale-info"] }
 either = { version = "1.6.1", default-features = false }
 yap = { version = "0.11.0", optional = true }

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -55,7 +55,7 @@ impl scale_decode::DecodeAsFields for Composite<TypeId> {
         // Build a Composite type to pass to a one-off visitor:
         static EMPTY_PATH: &Path<PortableForm> = &Path { segments: Vec::new() };
         let mut composite =
-            scale_decode::visitor::types::Composite::new(input, EMPTY_PATH, fields, types);
+            scale_decode::visitor::types::Composite::new(input, EMPTY_PATH, fields, types, false);
         // Decode into a Composite value from this:
         let val = visit_composite(&mut composite);
         // Consume remaining bytes and update input cursor:

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -371,7 +371,10 @@ mod test {
             }
         }
 
-        encode_decode_check(Compact(MyWrapper { inner: 123 }), Value::u128(123));
+        encode_decode_check(
+            Compact(MyWrapper { inner: 123 }),
+            Value::named_composite(vec![("inner", Value::u128(123))]),
+        );
     }
 
     #[test]
@@ -400,7 +403,10 @@ mod test {
             }
         }
 
-        encode_decode_check(Compact(MyWrapper(123)), Value::u128(123));
+        encode_decode_check(
+            Compact(MyWrapper(123)),
+            Value::unnamed_composite(vec![Value::u128(123)]),
+        );
     }
 
     #[test]

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -245,7 +245,7 @@ fn encode_vals_to_bitsequence<'a, T: 'a>(
     types: &PortableRegistry,
     out: &mut Vec<u8>,
 ) -> Result<(), Error> {
-    let format = scale_bits::Format::from_metadata(bits, types).map_err(|e| Error::custom(e))?;
+    let format = scale_bits::Format::from_metadata(bits, types).map_err(Error::custom)?;
     let mut bools = Vec::with_capacity(vals.len());
     for (idx, value) in vals.enumerate() {
         if let Some(v) = value.as_bool() {


### PR DESCRIPTION
With the improved error handling in `scale-encode` and `scale-decode`, this PR bumps the versions of those and removed now-unnecessary code.

Works locally, but won't pass CI until scale-encode and scale-decode have been released with these changes.

Part of a series:

- https://github.com/paritytech/scale-decode/pull/31
- https://github.com/paritytech/scale-encode/pull/13
- You are here: https://github.com/paritytech/scale-value/pull/40

Changes tested against Subxt; I'll update that next.