### PR TITLE
Prep for 0.13.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.13.0 (2023-11-10)
+
+This release:
+- Bumps `scale-decode` to its latest version.
+
 ## 0.12.0 (2023-08-02)
 
 Bumps `scale-encode` and `scale-decode` to their latest versions (0.5 and 0.9 respectively).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,3 @@ derive_more = { version = "0.99.17", default-features = false, features = ["disp
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 scale-decode = { version = "0.10.0", default-features = false, features = ["derive"] }
-
-[patch.crates-io]
-scale-decode = { path = "../scale-decode/scale-decode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -41,7 +41,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
 frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 scale-info = { version = "2.5.0", default-features = false }
-scale-decode = { version = "0.9.0", default-features = false }
+scale-decode = { version = "0.10.0", default-features = false }
 scale-encode = { version = "0.5.0", default-features = false, features = ["bits"] }
 scale-bits = { version = "0.4.0", default-features = false, features = ["serde", "scale-info"] }
 either = { version = "1.6.1", default-features = false }
@@ -53,4 +53,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["disp
 [dev-dependencies]
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-scale-decode = { version = "0.9.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.10.0", default-features = false, features = ["derive"] }
+
+[patch.crates-io]
+scale-decode = { path = "../scale-decode/scale-decode" }

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -70,9 +70,9 @@ impl scale_decode::DecodeAsFields for Composite<TypeId> {
 pub struct DecodeValueVisitor;
 
 impl scale_decode::IntoVisitor for Value<TypeId> {
-    type Visitor = DecodeValueVisitor;
+    type Visitor = scale_decode::visitor::VisitorWithCrateError<DecodeValueVisitor>;
     fn into_visitor() -> Self::Visitor {
-        DecodeValueVisitor
+        scale_decode::visitor::VisitorWithCrateError(DecodeValueVisitor)
     }
 }
 

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -211,9 +211,7 @@ fn encode_composite<T>(
 
 // skip into the target type past any newtype wrapper like things:
 fn find_single_entry_with_same_repr(type_id: u32, types: &PortableRegistry) -> u32 {
-    let Some(ty) = types.resolve(type_id) else {
-        return type_id
-    };
+    let Some(ty) = types.resolve(type_id) else { return type_id };
     match &ty.type_def {
         TypeDef::Tuple(tuple) if tuple.fields.len() == 1 => {
             find_single_entry_with_same_repr(tuple.fields[0].id, types)

--- a/src/string_impls/custom_parsers/hex.rs
+++ b/src/string_impls/custom_parsers/hex.rs
@@ -146,9 +146,7 @@ mod test {
             assert_eq!(err.start_loc, 0);
             assert_eq!(err.end_loc, Some(input.len()));
 
-            let ParseErrorKind::Custom(err) = err.err else {
-                panic!("expected custom error")
-            };
+            let ParseErrorKind::Custom(err) = err.err else { panic!("expected custom error") };
 
             assert_eq!(err, ParseHexError::WrongLength.to_string());
             assert_eq!(input, *cursor);
@@ -167,9 +165,7 @@ mod test {
             assert_eq!(err.start_loc, pos);
             assert!(err.end_loc.is_none());
 
-            let ParseErrorKind::Custom(err) = err.err else {
-                panic!("expected custom error")
-            };
+            let ParseErrorKind::Custom(err) = err.err else { panic!("expected custom error") };
 
             assert_eq!(err, ParseHexError::InvalidChar(bad_char).to_string());
             assert_eq!(input, *cursor);

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -59,9 +59,7 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
 
     // Attempt to base58-decode these chars.
     use base58::FromBase58;
-    let Ok(bytes) = maybe_ss58.from_base58() else {
-        return None
-    };
+    let Ok(bytes) = maybe_ss58.from_base58() else { return None };
 
     // decode length of address prefix.
     let prefix_len = match bytes.first() {


### PR DESCRIPTION
This release:
- Bumps `scale-decode` to its latest version.