### PR TITLE
Use scale-type-resolver to make encoding/decoding more generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,16 +41,17 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
 frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 scale-info = { version = "2.5.0", default-features = false }
-scale-decode = { version = "0.10.0", default-features = false }
-scale-encode = { version = "0.5.0", default-features = false, features = ["bits"] }
-scale-bits = { version = "0.4.0", default-features = false, features = ["serde", "scale-info"] }
+scale-decode = { version = "0.11.1", default-features = false }
+scale-encode = { version = "0.6.0", default-features = false, features = ["bits"] }
+scale-bits = { version = "0.5.0", default-features = false, features = ["serde", "scale-info"] }
 either = { version = "1.6.1", default-features = false }
 yap = { version = "0.11.0", optional = true }
 base58 = { version = "0.2.0", optional = true }
 blake2 = { version = "0.10.6", optional = true, default_features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
+scale-type-resolver = "0.1.1"
 
 [dev-dependencies]
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-scale-decode = { version = "0.10.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.11.1", default-features = false, features = ["derive"] }

--- a/src/at.rs
+++ b/src/at.rs
@@ -182,7 +182,7 @@ mod test {
         // References to valid locations are fine too:
         #[allow(clippy::needless_borrow)]
         {
-            assert_eq!(val.at(&"hello").at(&0), Some(&Value::u128(1)));
+            assert_eq!(val.at("hello").at(0), Some(&Value::u128(1)));
         }
     }
 

--- a/src/at.rs
+++ b/src/at.rs
@@ -180,7 +180,6 @@ mod test {
         // Strings can be used:
         assert_eq!(val.at("hello".to_string()).at(0), Some(&Value::u128(1)));
         // References to valid locations are fine too:
-        #[allow(clippy::needless_borrow)]
         {
             assert_eq!(val.at("hello").at(0), Some(&Value::u128(1)));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub mod scale {
     use crate::prelude::*;
     use scale_encode::EncodeAsType;
 
-    pub use crate::scale_impls::{DecodeError, TypeId};
+    pub use crate::scale_impls::DecodeError;
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
 
@@ -203,9 +203,9 @@ pub mod scale {
     /// a type ID, and a type registry from which we'll look up the relevant type information.
     pub fn decode_as_type(
         data: &mut &[u8],
-        ty_id: TypeId,
+        ty_id: u32,
         types: &PortableRegistry,
-    ) -> Result<crate::Value<TypeId>, DecodeError> {
+    ) -> Result<crate::Value<u32>, DecodeError> {
         crate::scale_impls::decode_value_as_type(data, ty_id, types)
     }
 
@@ -214,11 +214,11 @@ pub mod scale {
     /// up the relevant type information, and a buffer to encode the bytes to.
     pub fn encode_as_type<T: Clone>(
         value: &crate::Value<T>,
-        ty_id: TypeId,
+        ty_id: u32,
         types: &PortableRegistry,
         buf: &mut Vec<u8>,
     ) -> Result<(), EncodeError> {
-        value.encode_as_type_to(ty_id, types, buf)
+        value.encode_as_type_to(&ty_id, types, buf)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub mod scale {
     use crate::prelude::*;
     use scale_encode::EncodeAsType;
 
-    pub use crate::scale_impls::DecodeError;
+    pub use crate::scale_impls::{decode_any_value_as_type, DecodeError};
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub mod scale {
     use crate::prelude::*;
     use scale_encode::EncodeAsType;
 
-    pub use crate::scale_impls::{decode_any_value_as_type, DecodeError};
+    pub use crate::scale_impls::DecodeError;
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub mod serde {
 ///
 /// // Encode the Value to bytes:
 /// let mut bytes = Vec::new();
-/// scale_value::scale::encode_as_type(&value, type_id, &registry, &mut bytes).unwrap();
+/// scale_value::scale::encode_as_type(&value, &type_id, &registry, &mut bytes).unwrap();
 ///
 /// // Decode the bytes back into a matching Value.
 /// // This value contains contextual information about which type was used
 /// // to decode each part of it, which we can throw away with `.remove_context()`.
-/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, type_id, &registry).unwrap();
+/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, &type_id, &registry).unwrap();
 ///
 /// assert_eq!(value, new_value.remove_context());
 /// ```
@@ -197,28 +197,32 @@ pub mod scale {
     pub use crate::scale_impls::DecodeError;
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
+    pub use scale_type_resolver::TypeResolver;
 
     /// Attempt to decode some SCALE encoded bytes into a value, by providing a pointer
     /// to the bytes (which will be moved forwards as bytes are used in the decoding),
     /// a type ID, and a type registry from which we'll look up the relevant type information.
-    pub fn decode_as_type(
+    pub fn decode_as_type<R: TypeResolver>(
         data: &mut &[u8],
-        ty_id: u32,
-        types: &PortableRegistry,
-    ) -> Result<crate::Value<u32>, DecodeError> {
+        ty_id: &R::TypeId,
+        types: &R,
+    ) -> Result<crate::Value<R::TypeId>, DecodeError>
+    where
+        R::TypeId: Clone,
+    {
         crate::scale_impls::decode_value_as_type(data, ty_id, types)
     }
 
     /// Attempt to encode some [`crate::Value<T>`] into SCALE bytes, by providing a pointer to the
     /// type ID that we'd like to encode it as, a type registry from which we'll look
     /// up the relevant type information, and a buffer to encode the bytes to.
-    pub fn encode_as_type<T: Clone>(
+    pub fn encode_as_type<R: TypeResolver, T>(
         value: &crate::Value<T>,
-        ty_id: u32,
-        types: &PortableRegistry,
+        ty_id: &R::TypeId,
+        types: &R,
         buf: &mut Vec<u8>,
     ) -> Result<(), EncodeError> {
-        value.encode_as_type_to(&ty_id, types, buf)
+        value.encode_as_type_to(ty_id, types, buf)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,12 +202,13 @@ pub mod scale {
     /// Attempt to decode some SCALE encoded bytes into a value, by providing a pointer
     /// to the bytes (which will be moved forwards as bytes are used in the decoding),
     /// a type ID, and a type registry from which we'll look up the relevant type information.
-    pub fn decode_as_type<R: TypeResolver>(
+    pub fn decode_as_type<R>(
         data: &mut &[u8],
         ty_id: &R::TypeId,
         types: &R,
     ) -> Result<crate::Value<R::TypeId>, DecodeError>
     where
+        R: TypeResolver,
         R::TypeId: Clone,
     {
         crate::scale_impls::decode_value_as_type(data, ty_id, types)

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -23,7 +23,7 @@ use scale_info::PortableRegistry;
 // This is emitted if something goes wrong decoding into a Value.
 pub use scale_decode::visitor::DecodeError;
 
-/// Decode data according to the [`TypeId`] provided.
+/// Decode data according to the type id provided.
 /// The provided pointer to the data slice will be moved forwards as needed
 /// depending on what was decoded.
 pub fn decode_value_as_type(
@@ -40,8 +40,8 @@ pub fn decode_value_as_type(
     )
 }
 
-/// A more generic version of [`decode_value_as_type`], but in most cases you should
-/// just use [`decode_value_as_type`] because then no type params need to be configured.
+/// A more generic version of [`crate::scale::decode_as_type`], but in most cases you should
+/// just use [`crate::scale::decode_as_type`] because then no type params need to be configured.
 pub fn decode_any_value_as_type<T, R: TypeResolver>(
     data: &mut &[u8],
     ty_id: R::TypeId,

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -49,7 +49,7 @@ pub fn decode_any_value_as_type<T, R: TypeResolver>(
 ) -> Result<Value<T>, DecodeError>
 where
     T: From<R::TypeId>,
-    R::TypeId: Copy,
+    R::TypeId: Clone,
 {
     scale_decode::visitor::decode_with_visitor(
         data,
@@ -132,12 +132,12 @@ impl<From, To: Default> TypeIdMapper<From, To> for DefaultMapper {
 }
 
 pub struct FromMapper;
-impl<Fr: Copy, To> TypeIdMapper<Fr, To> for FromMapper
+impl<Fr: Clone, To> TypeIdMapper<Fr, To> for FromMapper
 where
     To: From<Fr>,
 {
     fn map(from: &Fr) -> To {
-        From::from(*from)
+        From::from(from.clone())
     }
 }
 

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -25,12 +25,13 @@ pub use scale_decode::visitor::DecodeError;
 /// Decode data according to the type id provided.
 /// The provided pointer to the data slice will be moved forwards as needed
 /// depending on what was decoded.
-pub fn decode_value_as_type<R: TypeResolver>(
+pub fn decode_value_as_type<R>(
     data: &mut &[u8],
     ty_id: &R::TypeId,
     types: &R,
 ) -> Result<Value<R::TypeId>, DecodeError>
 where
+    R: TypeResolver,
     R::TypeId: Clone,
 {
     scale_decode::visitor::decode_with_visitor(
@@ -113,8 +114,9 @@ impl<From, To: Default> TypeIdMapper<From, To> for DefaultMapper {
 }
 
 pub struct FromMapper;
-impl<Fr: Clone, To> TypeIdMapper<Fr, To> for FromMapper
+impl<Fr, To> TypeIdMapper<Fr, To> for FromMapper
 where
+    Fr: Clone,
     To: From<Fr>,
 {
     fn map(from: &Fr) -> To {
@@ -122,8 +124,9 @@ where
     }
 }
 
-impl<R: TypeResolver, T, F> scale_decode::visitor::Visitor for DecodeValueVisitor<R, T, F>
+impl<R, T, F> scale_decode::visitor::Visitor for DecodeValueVisitor<R, T, F>
 where
+    R: TypeResolver,
     F: TypeIdMapper<R::TypeId, T>,
 {
     type Value<'scale, 'info> = Value<T>;
@@ -288,10 +291,11 @@ where
 }
 
 /// Extract a named/unnamed Composite type out of scale_decode's Composite.
-fn visit_composite<R: TypeResolver, T, F>(
+fn visit_composite<R, T, F>(
     value: &mut scale_decode::visitor::types::Composite<'_, '_, R>,
 ) -> Result<Composite<T>, DecodeError>
 where
+    R: TypeResolver,
     F: TypeIdMapper<R::TypeId, T>,
 {
     let len = value.remaining();

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -40,6 +40,26 @@ pub fn decode_value_as_type(
     )
 }
 
+/// A more generic version of [`decode_value_as_type`], but in most cases you should
+/// just use [`decode_value_as_type`] because then no type params need to be configured.
+pub fn decode_any_value_as_type<T, R: TypeResolver>(
+    data: &mut &[u8],
+    ty_id: R::TypeId,
+    types: &R,
+) -> Result<Value<T>, DecodeError>
+where
+    T: From<R::TypeId>,
+    R::TypeId: Copy,
+{
+    scale_decode::visitor::decode_with_visitor(
+        data,
+        &ty_id,
+        types,
+        // note: in this case the `FromMapper` converts the u32 into a u32, and is just an identity mapping.
+        DecodeValueVisitor::<R, T, FromMapper>::new(),
+    )
+}
+
 // Sequences, Tuples and Arrays all have the same methods, so decode them in the same way:
 macro_rules! to_unnamed_composite {
     ($value:ident, $type_id:ident) => {{

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::TypeId;
+use core::marker::PhantomData;
+
 use crate::prelude::*;
 use crate::value_type::{Composite, Primitive, Value, ValueDef, Variant};
-use scale_decode::FieldIter;
+use scale_decode::{FieldIter, TypeResolver};
 use scale_info::{form::PortableForm, Path, PortableRegistry};
 
 // This is emitted if something goes wrong decoding into a Value.
@@ -27,217 +28,265 @@ pub use scale_decode::visitor::DecodeError;
 /// depending on what was decoded.
 pub fn decode_value_as_type(
     data: &mut &[u8],
-    ty_id: TypeId,
+    ty_id: u32,
     types: &PortableRegistry,
-) -> Result<Value<TypeId>, DecodeError> {
-    scale_decode::visitor::decode_with_visitor(data, ty_id, types, DecodeValueVisitor)
+) -> Result<Value<u32>, DecodeError> {
+    scale_decode::visitor::decode_with_visitor(
+        data,
+        &ty_id,
+        types,
+        // note: in this case the `FromMapper` converts the u32 into a u32, and is just an identity mapping.
+        DecodeValueVisitor::<PortableRegistry, u32, FromMapper>::new(),
+    )
 }
 
 // Sequences, Tuples and Arrays all have the same methods, so decode them in the same way:
 macro_rules! to_unnamed_composite {
     ($value:ident, $type_id:ident) => {{
         let mut vals = Vec::with_capacity($value.remaining());
-        while let Some(val) = $value.decode_item(DecodeValueVisitor) {
+        while let Some(val) = $value.decode_item(DecodeValueVisitor::<R, T, F>::new()) {
             let val = val?;
             vals.push(val);
         }
-        Ok(Value { value: ValueDef::Composite(Composite::Unnamed(vals)), context: $type_id.0 })
+        Ok(Value {
+            value: ValueDef::Composite(Composite::Unnamed(vals)),
+            context: F::map($type_id),
+        })
     }};
 }
 
 // We can't implement this on `Value<TypeId>` because we have no TypeId to assign to the value.
-impl scale_decode::DecodeAsFields for Composite<TypeId> {
-    fn decode_as_fields<'info>(
+impl scale_decode::DecodeAsFields for Composite<()> {
+    fn decode_as_fields<'resolver, R: TypeResolver>(
         input: &mut &[u8],
-        fields: &mut dyn FieldIter<'info>,
-        types: &'info PortableRegistry,
+        fields: &mut dyn FieldIter<'resolver, R::TypeId>,
+        types: &'resolver R,
     ) -> Result<Self, scale_decode::Error> {
         // Build a Composite type to pass to a one-off visitor:
-        static EMPTY_PATH: &Path<PortableForm> = &Path { segments: Vec::new() };
         let mut composite =
-            scale_decode::visitor::types::Composite::new(input, EMPTY_PATH, fields, types, false);
+            scale_decode::visitor::types::Composite::new(input, fields, types, false);
         // Decode into a Composite value from this:
-        let val = visit_composite(&mut composite);
+        let val = visit_composite::<R, (), DefaultMapper>(&mut composite);
         // Consume remaining bytes and update input cursor:
         composite.skip_decoding()?;
         *input = composite.bytes_from_undecoded();
-
-        val.map_err(From::from)
+        val.map_err(From::from).map(|v| v.map_context(|_| {}))
     }
 }
 
 /// A [`scale_decode::Visitor`] implementation for decoding into [`Value`]s.
-pub struct DecodeValueVisitor;
-
-impl scale_decode::IntoVisitor for Value<TypeId> {
-    type Visitor = scale_decode::visitor::VisitorWithCrateError<DecodeValueVisitor>;
-    fn into_visitor() -> Self::Visitor {
-        scale_decode::visitor::VisitorWithCrateError(DecodeValueVisitor)
+pub struct DecodeValueVisitor<R: TypeResolver, T, F> {
+    resolver: PhantomData<(R, T, F)>,
+}
+impl<R: TypeResolver, T, F> DecodeValueVisitor<R, T, F> {
+    pub fn new() -> Self {
+        DecodeValueVisitor { resolver: PhantomData }
     }
 }
 
-impl scale_decode::visitor::Visitor for DecodeValueVisitor {
-    type Value<'scale, 'info> = Value<TypeId>;
+impl scale_decode::IntoVisitor for Value<()> {
+    // Note: the ToDefaultMapping just removes all type ids here.
+    type AnyVisitor<R: scale_decode::TypeResolver> =
+        scale_decode::visitor::VisitorWithCrateError<DecodeValueVisitor<R, (), DefaultMapper>>;
+
+    fn into_visitor<R: scale_decode::TypeResolver>() -> Self::AnyVisitor<R> {
+        scale_decode::visitor::VisitorWithCrateError(DecodeValueVisitor::new())
+    }
+}
+
+pub trait TypeIdMapper<From, To> {
+    fn map(from: &From) -> To;
+}
+
+pub struct DefaultMapper;
+impl<From, To: Default> TypeIdMapper<From, To> for DefaultMapper {
+    fn map(from: &From) -> To {
+        Default::default()
+    }
+}
+
+pub struct FromMapper;
+impl<Fr: Copy, To> TypeIdMapper<Fr, To> for FromMapper
+where
+    To: From<Fr>,
+{
+    fn map(from: &Fr) -> To {
+        From::from(*from)
+    }
+}
+
+impl<R: TypeResolver, T, F> scale_decode::visitor::Visitor for DecodeValueVisitor<R, T, F>
+where
+    F: TypeIdMapper<R::TypeId, T>,
+{
+    type Value<'scale, 'info> = Value<T>;
     type Error = DecodeError;
+    type TypeResolver = R;
 
     fn visit_bool<'scale, 'info>(
         self,
         value: bool,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value::bool(value).map_context(|_| type_id.0))
+        Ok(Value::bool(value).map_context(|_| F::map(type_id)))
     }
     fn visit_char<'scale, 'info>(
         self,
         value: char,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value::char(value).map_context(|_| type_id.0))
+        Ok(Value::char(value).map_context(|_| F::map(type_id)))
     }
     fn visit_u8<'scale, 'info>(
         self,
         value: u8,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_u128(value as u128, type_id)
     }
     fn visit_u16<'scale, 'info>(
         self,
         value: u16,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_u128(value as u128, type_id)
     }
     fn visit_u32<'scale, 'info>(
         self,
         value: u32,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_u128(value as u128, type_id)
     }
     fn visit_u64<'scale, 'info>(
         self,
         value: u64,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_u128(value as u128, type_id)
     }
     fn visit_u128<'scale, 'info>(
         self,
         value: u128,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value::u128(value).map_context(|_| type_id.0))
+        Ok(Value::u128(value).map_context(|_| F::map(type_id)))
     }
-    fn visit_u256<'info>(
+    fn visit_u256<'scale, 'info>(
         self,
-        value: &'_ [u8; 32],
-        type_id: scale_decode::visitor::TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
-        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: type_id.0 })
+        value: &'scale [u8; 32],
+        type_id: &R::TypeId,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: F::map(type_id) })
     }
     fn visit_i8<'scale, 'info>(
         self,
         value: i8,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_i128(value as i128, type_id)
     }
     fn visit_i16<'scale, 'info>(
         self,
         value: i16,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_i128(value as i128, type_id)
     }
     fn visit_i32<'scale, 'info>(
         self,
         value: i32,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_i128(value as i128, type_id)
     }
     fn visit_i64<'scale, 'info>(
         self,
         value: i64,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_i128(value as i128, type_id)
     }
     fn visit_i128<'scale, 'info>(
         self,
         value: i128,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value::i128(value).map_context(|_| type_id.0))
+        Ok(Value::i128(value).map_context(|_| F::map(type_id)))
     }
-    fn visit_i256<'info>(
+    fn visit_i256<'scale, 'info>(
         self,
-        value: &'_ [u8; 32],
-        type_id: scale_decode::visitor::TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
-        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: type_id.0 })
+        value: &'scale [u8; 32],
+        type_id: &R::TypeId,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: F::map(type_id) })
     }
     fn visit_sequence<'scale, 'info>(
         self,
-        value: &mut scale_decode::visitor::types::Sequence<'scale, 'info>,
-        type_id: scale_decode::visitor::TypeId,
+        value: &mut scale_decode::visitor::types::Sequence<'scale, 'info, R>,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         to_unnamed_composite!(value, type_id)
     }
     fn visit_tuple<'scale, 'info>(
         self,
-        value: &mut scale_decode::visitor::types::Tuple<'scale, 'info>,
-        type_id: scale_decode::visitor::TypeId,
+        value: &mut scale_decode::visitor::types::Tuple<'scale, 'info, R>,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         to_unnamed_composite!(value, type_id)
     }
     fn visit_array<'scale, 'info>(
         self,
-        value: &mut scale_decode::visitor::types::Array<'scale, 'info>,
-        type_id: scale_decode::visitor::TypeId,
+        value: &mut scale_decode::visitor::types::Array<'scale, 'info, R>,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         to_unnamed_composite!(value, type_id)
     }
     fn visit_bitsequence<'scale, 'info>(
         self,
         value: &mut scale_decode::visitor::types::BitSequence<'scale>,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let bits: Result<_, _> = value.decode()?.collect();
-        Ok(Value { value: ValueDef::BitSequence(bits?), context: type_id.0 })
+        Ok(Value { value: ValueDef::BitSequence(bits?), context: F::map(type_id) })
     }
     fn visit_str<'scale, 'info>(
         self,
         value: &mut scale_decode::visitor::types::Str<'scale>,
-        type_id: scale_decode::visitor::TypeId,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value::string(value.as_str()?).map_context(|_| type_id.0))
+        Ok(Value::string(value.as_str()?).map_context(|_| F::map(type_id)))
     }
     fn visit_variant<'scale, 'info>(
         self,
-        value: &mut scale_decode::visitor::types::Variant<'scale, 'info>,
-        type_id: scale_decode::visitor::TypeId,
+        value: &mut scale_decode::visitor::types::Variant<'scale, 'info, R>,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        let values = visit_composite(value.fields())?;
+        let values = visit_composite::<R, T, F>(value.fields())?;
         Ok(Value {
             value: ValueDef::Variant(Variant { name: value.name().to_owned(), values }),
-            context: type_id.0,
+            context: F::map(type_id),
         })
     }
     fn visit_composite<'scale, 'info>(
         self,
-        value: &mut scale_decode::visitor::types::Composite<'scale, 'info>,
-        type_id: scale_decode::visitor::TypeId,
+        value: &mut scale_decode::visitor::types::Composite<'scale, 'info, R>,
+        type_id: &R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value { value: ValueDef::Composite(visit_composite(value)?), context: type_id.0 })
+        Ok(Value {
+            value: ValueDef::Composite(visit_composite::<R, T, F>(value)?),
+            context: F::map(type_id),
+        })
     }
 }
 
 /// Extract a named/unnamed Composite type out of scale_decode's Composite.
-fn visit_composite(
-    value: &mut scale_decode::visitor::types::Composite<'_, '_>,
-) -> Result<Composite<TypeId>, DecodeError> {
+fn visit_composite<R: TypeResolver, T, F>(
+    value: &mut scale_decode::visitor::types::Composite<'_, '_, R>,
+) -> Result<Composite<T>, DecodeError>
+where
+    F: TypeIdMapper<R::TypeId, T>,
+{
     let len = value.remaining();
     // if no fields, we'll always assume unnamed.
     let named = len > 0 && !value.has_unnamed_fields();
@@ -245,7 +294,7 @@ fn visit_composite(
     if named {
         let mut vals = Vec::with_capacity(len);
         let mut name = value.peek_name();
-        while let Some(v) = value.decode_item(DecodeValueVisitor) {
+        while let Some(v) = value.decode_item(DecodeValueVisitor::<R, T, F>::new()) {
             let v = v?;
             vals.push((name.expect("all fields should be named; we have checked").to_owned(), v));
             // get the next field name now we've decoded one.
@@ -254,7 +303,7 @@ fn visit_composite(
         Ok(Composite::Named(vals))
     } else {
         let mut vals = Vec::with_capacity(len);
-        while let Some(v) = value.decode_item(DecodeValueVisitor) {
+        while let Some(v) = value.decode_item(DecodeValueVisitor::<R, T, F>::new()) {
             let v = v?;
             vals.push(v);
         }
@@ -272,7 +321,7 @@ mod test {
 
     /// Given a type definition, return the PortableType and PortableRegistry
     /// that our decode functions expect.
-    fn make_type<T: scale_info::TypeInfo + 'static>() -> (TypeId, PortableRegistry) {
+    fn make_type<T: scale_info::TypeInfo + 'static>() -> (u32, PortableRegistry) {
         let m = scale_info::MetaType::new::<T>();
         let mut types = scale_info::Registry::new();
         let id = types.register_type(&m);
@@ -501,7 +550,7 @@ mod test {
             panic!("Couldn't get fields");
         };
         let mut fields =
-            c.fields.iter().map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
+            c.fields.iter().map(|f| scale_decode::Field::new(&f.ty.id, f.name.as_deref()));
 
         // get some bytes to decode from:
         let foo = Foo { a: "Hello".to_owned(), b: true, c: 123 };

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -18,7 +18,7 @@ use core::marker::PhantomData;
 use crate::prelude::*;
 use crate::value_type::{Composite, Primitive, Value, ValueDef, Variant};
 use scale_decode::{FieldIter, TypeResolver};
-use scale_info::{form::PortableForm, Path, PortableRegistry};
+use scale_info::PortableRegistry;
 
 // This is emitted if something goes wrong decoding into a Value.
 pub use scale_decode::visitor::DecodeError;
@@ -78,6 +78,12 @@ impl scale_decode::DecodeAsFields for Composite<()> {
 pub struct DecodeValueVisitor<R: TypeResolver, T, F> {
     resolver: PhantomData<(R, T, F)>,
 }
+impl<R: TypeResolver, T, F> Default for DecodeValueVisitor<R, T, F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<R: TypeResolver, T, F> DecodeValueVisitor<R, T, F> {
     pub fn new() -> Self {
         DecodeValueVisitor { resolver: PhantomData }
@@ -100,7 +106,7 @@ pub trait TypeIdMapper<From, To> {
 
 pub struct DefaultMapper;
 impl<From, To: Default> TypeIdMapper<From, To> for DefaultMapper {
-    fn map(from: &From) -> To {
+    fn map(_from: &From) -> To {
         Default::default()
     }
 }

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -27,7 +27,7 @@ pub use scale_decode::visitor::DecodeError;
 /// depending on what was decoded.
 pub fn decode_value_as_type<R: TypeResolver>(
     data: &mut &[u8],
-    ty_id: R::TypeId,
+    ty_id: &R::TypeId,
     types: &R,
 ) -> Result<Value<R::TypeId>, DecodeError>
 where
@@ -35,9 +35,8 @@ where
 {
     scale_decode::visitor::decode_with_visitor(
         data,
-        &ty_id,
+        ty_id,
         types,
-        // note: in this case the `FromMapper` converts the u32 into a u32, and is just an identity mapping.
         DecodeValueVisitor::<R, R::TypeId, FromMapper>::new(),
     )
 }
@@ -358,7 +357,7 @@ mod test {
         let (id, portable_registry) = make_type::<Ty>();
 
         // Can we decode?
-        let val = decode_value_as_type(encoded, id, &portable_registry).expect("decoding failed");
+        let val = decode_value_as_type(encoded, &id, &portable_registry).expect("decoding failed");
         // Is the decoded value what we expected?
         assert_eq!(val.remove_context(), ex, "decoded value does not look like what we expected");
         // Did decoding consume all of the encoded bytes, as expected?

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -212,7 +212,6 @@ fn encode_composite<'a, T, R: TypeResolver>(
         let (inner_type_id, inner_is_different) =
             find_single_entry_with_same_repr::<R>(type_id, types)
                 .map_err(|err| Error::new(ErrorKind::TypeNotFound(format!("{:?}", err))))?;
-        // Todo/Question: Of course this is completely stupid, we should probably add `PartialEq` bound for R::TypeId in general;
         if inner_is_different {
             let mut temp_out = Vec::new();
             if let Ok(()) = do_encode_composite(value, inner_type_id, types, &mut temp_out) {
@@ -241,8 +240,9 @@ fn encode_composite<'a, T, R: TypeResolver>(
     Err(original_error)
 }
 
-/// skip into the target type past any newtype wrapper like things.
+/// Skip into the target type past any newtype wrapper like things.
 /// Also returns a bool indicating whether we skipped into something or not.
+/// This bool is true when the returned id is different from the id that was passed in.
 fn find_single_entry_with_same_repr<'a, R: TypeResolver>(
     type_id: &'a R::TypeId,
     types: &'a R,

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -97,27 +97,6 @@ fn encode_composite<'a, T, R: TypeResolver>(
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        // let mut visit_tuple_or_composite = || match value {
-        //     Composite::Named(vals) => {
-        //         let keyvals =
-        //             vals.iter().map(|(key, val)| (Some(&**key), CompositeField::new(val)));
-        //         EncodeComposite::new(keyvals).encode_composite_as_type_to(type_id, types, out)
-        //     }
-        //     Composite::Unnamed(vals) => {
-        //         let vals = vals.iter().map(|val| (None, CompositeField::new(val)));
-        //         EncodeComposite::new(vals).encode_composite_as_type_to(type_id, types, out)
-        //     }
-        // };
-
-        // let visitor = scale_type_resolver::visitor::new::<'_, (), R::TypeId, Result<(), Error>, _>(
-        //     (),
-        //     |_: (), err: UnhandledKind| {
-        //         Err(Error::new(ErrorKind::Custom(Box::new(StringError(format!("{:?}", err))))))
-        //     },
-        // )
-        // .visit_tuple(|_, _| visit_tuple_or_composite())
-        // .visit_composite(|_, _| visit_tuple_or_composite());
-
         struct EncodingVisitor<'a, T, R: TypeResolver> {
             value: &'a Composite<T>,
             out: &'a mut Vec<u8>,

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -19,17 +19,13 @@ use crate::prelude::*;
 use crate::value_type::{Composite, Primitive, Value, ValueDef, Variant};
 use codec::{Compact, Encode};
 use scale_bits::Bits;
-use scale_decode::{TypeResolver, Visitor};
+use scale_decode::TypeResolver;
 use scale_encode::error::ErrorKind;
 use scale_encode::{error::Kind, EncodeAsFields, EncodeAsType, Error};
 use scale_encode::{
     Composite as EncodeComposite, CompositeField, FieldIter, Variant as EncodeVariant,
 };
-use scale_info::form::PortableForm;
-use scale_info::{PortableRegistry, TypeDef, TypeDefBitSequence};
 
-pub use scale_encode::Error as EncodeError;
-use scale_type_resolver::visitor::ConcreteResolvedTypeVisitor;
 use scale_type_resolver::UnhandledKind;
 
 impl<T> EncodeAsType for Value<T> {
@@ -209,10 +205,10 @@ fn encode_composite<'a, T, R: TypeResolver>(
             }
 
             fn visit_array(self, array_ty_id: &'a Self::TypeId, array_len: usize) -> Self::Value {
-                if self.value.len() != array_len as usize {
+                if self.value.len() != array_len {
                     return Err(Error::new(ErrorKind::WrongLength {
                         actual_len: self.value.len(),
-                        expected_len: array_len as usize,
+                        expected_len: array_len,
                     }));
                 }
                 for (idx, val) in self.value.values().enumerate() {
@@ -449,6 +445,7 @@ mod test {
 
     use super::*;
     use codec::{Compact, Encode};
+    use scale_info::PortableRegistry;
 
     /// Given a type definition, return the PortableType and PortableRegistry
     /// that our decode functions expect.

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -19,5 +19,4 @@ mod encode;
 pub use decode::{decode_value_as_type, DecodeError, DecodeValueVisitor};
 pub use encode::EncodeError;
 
-/// A type ID which can be resolved into a type given a [`::scale_info::PortableRegistry`].
-pub type TypeId = u32;
+// pub type TypeId = u32;

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -16,7 +16,6 @@
 mod decode;
 mod encode;
 
-pub use decode::{decode_value_as_type, DecodeError, DecodeValueVisitor};
-pub use encode::EncodeError;
+pub use decode::{decode_value_as_type, DecodeError};
 
 // pub type TypeId = u32;

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -17,5 +17,3 @@ mod decode;
 mod encode;
 
 pub use decode::{decode_any_value_as_type, decode_value_as_type, DecodeError};
-
-// pub type TypeId = u32;

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -16,6 +16,6 @@
 mod decode;
 mod encode;
 
-pub use decode::{decode_value_as_type, DecodeError};
+pub use decode::{decode_any_value_as_type, decode_value_as_type, DecodeError};
 
 // pub type TypeId = u32;

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -16,4 +16,4 @@
 mod decode;
 mod encode;
 
-pub use decode::{decode_any_value_as_type, decode_value_as_type, DecodeError};
+pub use decode::{decode_value_as_type, DecodeError};


### PR DESCRIPTION
This PR makes the encoding and decoding of generic generic over the type of `TypeResolver` used.

The implementation of the visitors was a bit tricky, let me know if I can help with any walk through in the code.