### PR TITLE
A couple more tweaks for scale value update PR

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub mod serde {
 ///
 /// // Encode the Value to bytes:
 /// let mut bytes = Vec::new();
-/// scale_value::scale::encode_as_type(&value, type_id, &registry, &mut bytes).unwrap();
+/// scale_value::scale::encode_as_type(&value, &type_id, &registry, &mut bytes).unwrap();
 ///
 /// // Decode the bytes back into a matching Value.
 /// // This value contains contextual information about which type was used
 /// // to decode each part of it, which we can throw away with `.remove_context()`.
-/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, type_id, &registry).unwrap();
+/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, &type_id, &registry).unwrap();
 ///
 /// assert_eq!(value, new_value.remove_context());
 /// ```
@@ -197,28 +197,32 @@ pub mod scale {
     pub use crate::scale_impls::DecodeError;
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
+    pub use scale_type_resolver::TypeResolver;
 
     /// Attempt to decode some SCALE encoded bytes into a value, by providing a pointer
     /// to the bytes (which will be moved forwards as bytes are used in the decoding),
     /// a type ID, and a type registry from which we'll look up the relevant type information.
-    pub fn decode_as_type(
+    pub fn decode_as_type<R: TypeResolver>(
         data: &mut &[u8],
-        ty_id: u32,
-        types: &PortableRegistry,
-    ) -> Result<crate::Value<u32>, DecodeError> {
+        ty_id: &R::TypeId,
+        types: &R,
+    ) -> Result<crate::Value<R::TypeId>, DecodeError>
+    where
+        R::TypeId: Clone,
+    {
         crate::scale_impls::decode_value_as_type(data, ty_id, types)
     }
 
     /// Attempt to encode some [`crate::Value<T>`] into SCALE bytes, by providing a pointer to the
     /// type ID that we'd like to encode it as, a type registry from which we'll look
     /// up the relevant type information, and a buffer to encode the bytes to.
-    pub fn encode_as_type<T: Clone>(
+    pub fn encode_as_type<R: TypeResolver, T>(
         value: &crate::Value<T>,
-        ty_id: u32,
-        types: &PortableRegistry,
+        ty_id: &R::TypeId,
+        types: &R,
         buf: &mut Vec<u8>,
     ) -> Result<(), EncodeError> {
-        value.encode_as_type_to(&ty_id, types, buf)
+        value.encode_as_type_to(ty_id, types, buf)
     }
 }
 

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -27,7 +27,7 @@ pub use scale_decode::visitor::DecodeError;
 /// depending on what was decoded.
 pub fn decode_value_as_type<R: TypeResolver>(
     data: &mut &[u8],
-    ty_id: R::TypeId,
+    ty_id: &R::TypeId,
     types: &R,
 ) -> Result<Value<R::TypeId>, DecodeError>
 where
@@ -35,9 +35,8 @@ where
 {
     scale_decode::visitor::decode_with_visitor(
         data,
-        &ty_id,
+        ty_id,
         types,
-        // note: in this case the `FromMapper` converts the u32 into a u32, and is just an identity mapping.
         DecodeValueVisitor::<R, R::TypeId, FromMapper>::new(),
     )
 }
@@ -358,7 +357,7 @@ mod test {
         let (id, portable_registry) = make_type::<Ty>();
 
         // Can we decode?
-        let val = decode_value_as_type(encoded, id, &portable_registry).expect("decoding failed");
+        let val = decode_value_as_type(encoded, &id, &portable_registry).expect("decoding failed");
         // Is the decoded value what we expected?
         assert_eq!(val.remove_context(), ex, "decoded value does not look like what we expected");
         // Did decoding consume all of the encoded bytes, as expected?


### PR DESCRIPTION
- Expose the generic signatures from the lib else it's all for nothing :)
- I don't know why `encode_as_type` ever took `T: Clone`: remove the `Clone` bound.
- Don't return error from `find_single_entry_with_same_repr` since old version didn't and we'll hit it elsewhere anyways.