### PR TITLE
add `decode_as_fields` and prep for small patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+
+## 0.14.0 (2024-03-04)
+
+## Added
+
+A `scale_value::decode_as_fields` function was added that can decode a series of values from some bytes given an iterator of type ids. Previously it was only possible through the `scale_decode::DecodeAsFields` implementation of `scale_value::Composite<()>`. With the new function `scale_value::Composite<R::TypeId>`'s can be decoded for any type resolver `R`.
+
 ## 0.14.0 (2024-02-27)
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -17,15 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 default = ["std", "serde", "from-string", "parser-ss58"]
 
 # Only work in "std" environments:
-std = [
-    "scale-decode/std",
-    "scale-encode/std",
-    "scale-bits/std",
-    "scale-info/std",
-    "either/use_std",
-    "serde?/std",
-    "serde_json/std"
-]
+std = ["scale-decode/std", "scale-encode/std", "scale-bits/std", "scale-info/std", "either/use_std", "serde?/std", "serde_json/std"]
 
 # Enable support for parsing strings into Values.
 from-string = ["dep:yap"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ pub mod serde {
 /// ```
 pub mod scale {
     use crate::prelude::*;
+    use scale_decode::FieldIter;
     use scale_encode::EncodeAsType;
 
     pub use crate::scale_impls::DecodeError;
@@ -212,6 +213,21 @@ pub mod scale {
         R::TypeId: Clone,
     {
         crate::scale_impls::decode_value_as_type(data, ty_id, types)
+    }
+
+    /// Attempt to decode some SCALE encoded bytes into multiple values, by providing a pointer
+    /// to the bytes (which will be moved forwards as bytes are used in the decoding),
+    /// and an iterator of fields, where each field contains a  type ID and optionally a field name.
+    pub fn decode_as_fields<'resolver, R>(
+        input: &mut &[u8],
+        fields: &mut dyn FieldIter<'resolver, R::TypeId>,
+        types: &'resolver R,
+    ) -> Result<crate::Composite<R::TypeId>, DecodeError>
+    where
+        R: TypeResolver,
+        R::TypeId: Clone,
+    {
+        crate::scale_impls::decode_composite_as_fields(input, fields, types)
     }
 
     /// Attempt to encode some [`crate::Value<T>`] into SCALE bytes, by providing a pointer to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ pub mod scale {
 
     /// Attempt to decode some SCALE encoded bytes into multiple values, by providing a pointer
     /// to the bytes (which will be moved forwards as bytes are used in the decoding),
-    /// and an iterator of fields, where each field contains a  type ID and optionally a field name.
+    /// and an iterator of fields, where each field contains a type ID and optionally a field name.
     pub fn decode_as_fields<'resolver, R>(
         input: &mut &[u8],
         fields: &mut dyn FieldIter<'resolver, R::TypeId>,

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -16,4 +16,4 @@
 mod decode;
 mod encode;
 
-pub use decode::{decode_value_as_type, DecodeError};
+pub use decode::{decode_composite_as_fields, decode_value_as_type, DecodeError};


### PR DESCRIPTION
## Added

A `scale_value::decode_as_fields` function was added that can decode a series of values from some bytes given an iterator of type ids. Previously it was only possible through the `scale_decode::DecodeAsFields` implementation of `scale_value::Composite<()>`. With the new function `scale_value::Composite<R::TypeId>`'s can be decoded for any type resolver `R`.