### PR TITLE
Bump to scale-type-resolver 0.2 and prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.15.0 (2024-04-29)
 
-## 0.14.0 (2024-03-04)
+This release bumps `scale-type-resolver`, `scale-encode`, `scale-decode` and `scale-bits` to their latest versions.
 
-## Added
+## 0.14.1 (2024-03-04)
+
+### Added
 
 A `scale_value::decode_as_fields` function was added that can decode a series of values from some bytes given an iterator of type ids. Previously it was only possible through the `scale_decode::DecodeAsFields` implementation of `scale_value::Composite<()>`. With the new function `scale_value::Composite<R::TypeId>`'s can be decoded for any type resolver `R`.
 
 ## 0.14.0 (2024-02-27)
 
-## Changed
+### Changed
 
 The crate now uses [`scale-type-resolver`](https://github.com/paritytech/scale-type-resolver) to be generic over the provider of type information that is used when encoding and decoding `Value`s.
 
@@ -34,7 +37,7 @@ but now it decodes to `Value::named_composite(vec![("inner", Value::u128(123))])
 
 ## 0.11.0 (2023-07-18)
 
-## Added
+### Added
 
 - Adds support for `no_std` environments; disable the "std" feature flag for this. ([#38](https://github.com/paritytech/scale-value/pull/38))
   This PR makes a couple of small breaking changes:
@@ -43,7 +46,7 @@ but now it decodes to `Value::named_composite(vec![("inner", Value::u128(123))])
   - `ParseErrorKind::Custom` errors are now strings rather than boxed `std::error::Error`s to play nicer with `no_std`.
 - Adds a `value!` macro to make constructing `Value`'s much easier; think `serde_json::value!`. ([#36](https://github.com/paritytech/scale-value/pull/36))
 
-## Changed
+### Changed
 
 - Bumps `scale-encode` and `scale-decode` to their latest versions (0.4 and 0.8 respectively).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,8 @@ scale-type-resolver = "0.1.1"
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 scale-decode = { version = "0.11.1", default-features = false, features = ["derive"] }
+
+[patch.crates-io]
+scale-type-resolver = { path = "../scale-type-resolver" }
+scale-encode = { path = "../scale-encode/scale-encode" }
+scale-decode = { path = "../scale-decode/scale-decode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,22 +33,17 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
 frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 scale-info = { version = "2.5.0", default-features = false }
-scale-decode = { version = "0.11.1", default-features = false }
-scale-encode = { version = "0.6.0", default-features = false, features = ["bits"] }
-scale-bits = { version = "0.5.0", default-features = false, features = ["serde", "scale-info"] }
+scale-decode = { version = "0.12.0", default-features = false }
+scale-encode = { version = "0.7.0", default-features = false, features = ["bits"] }
+scale-bits = { version = "0.6.0", default-features = false, features = ["serde", "scale-info"] }
 either = { version = "1.6.1", default-features = false }
 yap = { version = "0.11.0", optional = true }
 base58 = { version = "0.2.0", optional = true }
 blake2 = { version = "0.10.6", optional = true, default_features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
-scale-type-resolver = "0.1.1"
+scale-type-resolver = "0.2.0"
 
 [dev-dependencies]
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-scale-decode = { version = "0.11.1", default-features = false, features = ["derive"] }
-
-[patch.crates-io]
-scale-type-resolver = { path = "../scale-type-resolver" }
-scale-encode = { path = "../scale-encode/scale-encode" }
-scale-decode = { path = "../scale-decode/scale-decode" }
+scale-decode = { version = "0.12.0", default-features = false, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub mod scale {
     /// a type ID, and a type registry from which we'll look up the relevant type information.
     pub fn decode_as_type<R>(
         data: &mut &[u8],
-        ty_id: &R::TypeId,
+        ty_id: R::TypeId,
         types: &R,
     ) -> Result<crate::Value<R::TypeId>, DecodeError>
     where
@@ -235,7 +235,7 @@ pub mod scale {
     /// up the relevant type information, and a buffer to encode the bytes to.
     pub fn encode_as_type<R: TypeResolver, T>(
         value: &crate::Value<T>,
-        ty_id: &R::TypeId,
+        ty_id: R::TypeId,
         types: &R,
         buf: &mut Vec<u8>,
     ) -> Result<(), EncodeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub mod serde {
 ///
 /// // Encode the Value to bytes:
 /// let mut bytes = Vec::new();
-/// scale_value::scale::encode_as_type(&value, &type_id, &registry, &mut bytes).unwrap();
+/// scale_value::scale::encode_as_type(&value, type_id, &registry, &mut bytes).unwrap();
 ///
 /// // Decode the bytes back into a matching Value.
 /// // This value contains contextual information about which type was used
 /// // to decode each part of it, which we can throw away with `.remove_context()`.
-/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, &type_id, &registry).unwrap();
+/// let new_value = scale_value::scale::decode_as_type(&mut &*bytes, type_id, &registry).unwrap();
 ///
 /// assert_eq!(value, new_value.remove_context());
 /// ```

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -135,9 +135,7 @@ trait ContextFromTypeId<TypeId, Output> {
 /// Return () for our value context.
 pub struct EmptyContext;
 impl<TypeId> ContextFromTypeId<TypeId, ()> for EmptyContext {
-    fn context_from_type_id(_type_id: &TypeId) {
-        
-    }
+    fn context_from_type_id(_type_id: &TypeId) {}
 }
 
 /// Return the type ID for our value context.

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -55,7 +55,7 @@ where
 {
     // Build a Composite type to pass to a one-off visitor:
     let mut composite = scale_decode::visitor::types::Composite::new(
-        std::iter::empty(),
+        core::iter::empty(),
         input,
         fields,
         types,
@@ -93,7 +93,7 @@ impl scale_decode::DecodeAsFields for Composite<()> {
     ) -> Result<Self, scale_decode::Error> {
         // Build a Composite type to pass to a one-off visitor:
         let mut composite = scale_decode::visitor::types::Composite::new(
-            std::iter::empty(),
+            core::iter::empty(),
             input,
             fields,
             types,
@@ -126,7 +126,7 @@ impl scale_decode::IntoVisitor for Value<()> {
 /// - We need to be able to decode into [`Value<TypeId>`] via the [`decode_value_as_type`] fn
 ///   above.
 ///
-/// This trait basically allows us to handle each case by havign a function that is given a
+/// This trait basically allows us to handle each case by having a function that is given a
 /// `TypeId` and decides whether to hand back `()` or the `TypeId`.
 trait ContextFromTypeId<TypeId, Output> {
     fn context_from_type_id(type_id: &TypeId) -> Output;

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -135,8 +135,8 @@ trait ContextFromTypeId<TypeId, Output> {
 /// Return () for our value context.
 pub struct EmptyContext;
 impl<TypeId> ContextFromTypeId<TypeId, ()> for EmptyContext {
-    fn context_from_type_id(_type_id: &TypeId) -> () {
-        ()
+    fn context_from_type_id(_type_id: &TypeId) {
+        
     }
 }
 
@@ -222,11 +222,11 @@ where
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::u128(value).map_context(|_| F::context_from_type_id(&type_id)))
     }
-    fn visit_u256<'scale, 'info>(
+    fn visit_u256<'info>(
         self,
-        value: &'scale [u8; 32],
+        value: &[u8; 32],
         type_id: R::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
         Ok(Value {
             value: ValueDef::Primitive(Primitive::U256(*value)),
             context: F::context_from_type_id(&type_id),
@@ -267,11 +267,11 @@ where
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::i128(value).map_context(|_| F::context_from_type_id(&type_id)))
     }
-    fn visit_i256<'scale, 'info>(
+    fn visit_i256<'info>(
         self,
-        value: &'scale [u8; 32],
+        value: &[u8; 32],
         type_id: R::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
         Ok(Value {
             value: ValueDef::Primitive(Primitive::U256(*value)),
             context: F::context_from_type_id(&type_id),

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -54,7 +54,13 @@ where
     R::TypeId: Clone,
 {
     // Build a Composite type to pass to a one-off visitor:
-    let mut composite = scale_decode::visitor::types::Composite::new(input, fields, types, false);
+    let mut composite = scale_decode::visitor::types::Composite::new(
+        std::iter::empty(),
+        input,
+        fields,
+        types,
+        false,
+    );
     // Decode into a Composite value from this:
     let val = visit_composite::<R, R::TypeId, TypeIdContext>(&mut composite)?;
     // Consume remaining bytes and update input cursor:
@@ -86,8 +92,13 @@ impl scale_decode::DecodeAsFields for Composite<()> {
         types: &'resolver R,
     ) -> Result<Self, scale_decode::Error> {
         // Build a Composite type to pass to a one-off visitor:
-        let mut composite =
-            scale_decode::visitor::types::Composite::new(input, fields, types, false);
+        let mut composite = scale_decode::visitor::types::Composite::new(
+            std::iter::empty(),
+            input,
+            fields,
+            types,
+            false,
+        );
         // Decode into a Composite value from this:
         let val = visit_composite::<R, (), EmptyContext>(&mut composite);
         // Consume remaining bytes and update input cursor:
@@ -216,7 +227,10 @@ where
         value: &'scale [u8; 32],
         type_id: R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: F::context_from_type_id(&type_id) })
+        Ok(Value {
+            value: ValueDef::Primitive(Primitive::U256(*value)),
+            context: F::context_from_type_id(&type_id),
+        })
     }
     fn visit_i8<'scale, 'info>(
         self,
@@ -258,7 +272,10 @@ where
         value: &'scale [u8; 32],
         type_id: R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-        Ok(Value { value: ValueDef::Primitive(Primitive::U256(*value)), context: F::context_from_type_id(&type_id) })
+        Ok(Value {
+            value: ValueDef::Primitive(Primitive::U256(*value)),
+            context: F::context_from_type_id(&type_id),
+        })
     }
     fn visit_sequence<'scale, 'info>(
         self,
@@ -287,7 +304,10 @@ where
         type_id: R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let bits: Result<_, _> = value.decode()?.collect();
-        Ok(Value { value: ValueDef::BitSequence(bits?), context: F::context_from_type_id(&type_id) })
+        Ok(Value {
+            value: ValueDef::BitSequence(bits?),
+            context: F::context_from_type_id(&type_id),
+        })
     }
     fn visit_str<'scale, 'info>(
         self,

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -79,10 +79,10 @@ impl<T> EncodeAsFields for Composite<T> {
 // can't handle encoding to sequences/arrays. However, we can encode safely into sequences here because we can inspect the
 // values we have and more safely skip newtype wrappers without also skipping through types that might represent 1-value
 // sequences/arrays for instance.
-fn encode_composite<'a, T, R: TypeResolver>(
+fn encode_composite<T, R: TypeResolver>(
     value: &Composite<T>,
     mut type_id: R::TypeId,
-    types: &'a R,
+    types: &R,
     out: &mut Vec<u8>,
 ) -> Result<(), Error> {
     // Encode our composite Value as-is (pretty much; we will try to
@@ -229,13 +229,13 @@ fn encode_composite<'a, T, R: TypeResolver>(
 /// Skip into the target type past any newtype wrapper like things.
 /// Also returns a bool indicating whether we skipped into something or not.
 /// This bool is true when the returned id is different from the id that was passed in.
-fn find_single_entry_with_same_repr<'a, R: TypeResolver>(
+fn find_single_entry_with_same_repr<R: TypeResolver>(
     type_id: R::TypeId,
-    types: &'a R,
+    types: &R,
 ) -> (R::TypeId, bool) {
-    fn do_find<'a, R: TypeResolver>(
+    fn do_find<R: TypeResolver>(
         type_id: R::TypeId,
-        types: &'a R,
+        types: &R,
         type_id_has_changed: bool,
     ) -> (R::TypeId, bool) {
         let ctx = (type_id.clone(), type_id_has_changed);


### PR DESCRIPTION
This release bumps `scale-type-resolver`, `scale-encode`, `scale-decode` and `scale-bits` to their latest versions.

I renamed a couple of the `FromMapper` bits to hopeuflly make it clearer what it does, but otherwise the changes just accomodate the above updates.