### PR TITLE
Prep for 0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.15.1 (2024-05-08)
+
+### Fixed
+
+- Fix an infinite loop when trying to encode Composite values of the wrong shape ((#48)[https://github.com/paritytech/scale-value/pull/48])
+
 ## 0.15.0 (2024-04-29)
 
 This release bumps `scale-type-resolver`, `scale-encode`, `scale-decode` and `scale-bits` to their latest versions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
### Fixed

- Fix an infinite loop when trying to encode Composite values of the wrong shape ((#48)[https://github.com/paritytech/scale-value/pull/48])