### PR TITLE
Prep for 0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.0 (2024-05-15)
+
+This release:
+- Bumps `scale-decode` to its latest version (0.13.0).
+
 ## 0.15.1 (2024-05-08)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -33,7 +33,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
 frame-metadata = { version = "15.0.0", default-features = false, features = ["v14"] }
 scale-info = { version = "2.5.0", default-features = false }
-scale-decode = { version = "0.12.0", default-features = false }
+scale-decode = { version = "0.13.0", default-features = false }
 scale-encode = { version = "0.7.0", default-features = false, features = ["bits"] }
 scale-bits = { version = "0.6.0", default-features = false, features = ["serde", "scale-info"] }
 either = { version = "1.6.1", default-features = false }
@@ -46,4 +46,4 @@ scale-type-resolver = "0.2.0"
 [dev-dependencies]
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-scale-decode = { version = "0.12.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.13.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## 0.16.0 (2024-05-15)

This release:
- Bumps `scale-decode` to its latest version (0.13.0).