### PR TITLE
Prep to release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.1 (2024-07-24)
+
+This release:
+- Adds a "tracing decoder" (via `scale_value::scale::tracing::{decode_as_type,*}`), which is like `scale_value::scale::decode_as_type`, but traces and hands back much more detail in case of a decoding failure, so that it's easier to track down where decoding failed. This is particularly useful when working with historic type information, which must be provided independently and could easily be misaligned with reality. ([#52](https://github.com/paritytech/scale-value/pull/52))
+
 ## 0.16.0 (2024-05-15)
 
 This release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
Doign a patch release since we don't change anything, just add this tracing API. Saves having to bump a bunch of other crates!

## 0.16.1 (2024-07-24)

This release:
- Adds a "tracing decoder" (via `scale_value::scale::tracing::{decode_as_type,*}`), which is like `scale_value::scale::decode_as_type`, but traces and hands back much more detail in case of a decoding failure, so that it's easier to track down where decoding failed. This is particularly useful when working with historic type information, which must be provided independently and could easily be misaligned with reality. ([#52](https://github.com/paritytech/scale-value/pull/52))