### PR TITLE
Prep to release v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This release adds `scale_value::stringify::to_writer` and `scale_value::stringif
 
 `scale_value::stringify::to_writer_custom` allows for custom formatting of values, including a "pretty" spaced/indented formatting and a "compact" formatting which removes all unnecessary spaces. It also allows customising of the indentation and for custom formatters to be applied, as well as displaying the contexts of values if desired.
 
+See [#52](https://github.com/paritytech/scale-value/pull/52) for more information.
+
 ## 0.16.1 (2024-07-24)
 
 This release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.2 (2024-08-08)
+
+This release adds `scale_value::stringify::to_writer` and `scale_value::stringify::to_writer_custom` (to align with the already present `scale_value::stringify::from_str_custom`), and also exposes a new `scale_value::stringiy::custom_formatters` containing a formatter for displaying things as hex.
+
+`scale_value::stringify::to_writer_custom` allows for custom formatting of values, including a "pretty" spaced/indented formatting and a "compact" formatting which removes all unnecessary spaces. It also allows customising of the indentation and for custom formatters to be applied, as well as displaying the contexts of values if desired.
+
 ## 0.16.1 (2024-07-24)
 
 This release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
## 0.16.2 (2024-08-08)

This release adds `scale_value::stringify::to_writer` and `scale_value::stringify::to_writer_custom` (to align with the already present `scale_value::stringify::from_str_custom`), and also exposes a new `scale_value::stringiy::custom_formatters` containing a formatter for displaying things as hex.

`scale_value::stringify::to_writer_custom` allows for custom formatting of values, including a "pretty" spaced/indented formatting and a "compact" formatting which removes all unnecessary spaces. It also allows customising of the indentation and for custom formatters to be applied, as well as displaying the contexts of values if desired.

See [#52](https://github.com/paritytech/scale-value/pull/52) for more information.