### PR TITLE
Export ValueVisitor and prep for 0.16.3 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.3 (2024-09-25)
+
+This release exports `scale_value::scale::ValueVisitor<TypeResolver>`, allowing the values to be created from functions like `scale_decode::visitor::decode_with_visitor`.
+
 ## 0.16.2 (2024-08-08)
 
 This release adds `scale_value::stringify::to_writer` and `scale_value::stringify::to_writer_custom` (to align with the already present `scale_value::stringify::from_str_custom`), and also exposes a new `scale_value::stringiy::custom_formatters` containing a formatter for displaying things as hex.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-value"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub mod scale {
     use scale_decode::FieldIter;
     use scale_encode::EncodeAsType;
 
-    pub use crate::scale_impls::DecodeError;
+    pub use crate::scale_impls::{DecodeError, ValueVisitor};
     pub use scale_encode::Error as EncodeError;
     pub use scale_info::PortableRegistry;
     pub use scale_type_resolver::TypeResolver;

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -22,6 +22,9 @@ use scale_decode::{FieldIter, TypeResolver};
 // This is emitted if something goes wrong decoding into a Value.
 pub use scale_decode::visitor::DecodeError;
 
+/// A visitor that can be used to decode types into [`Value`]s.
+pub type ValueVisitor<Resolver> = DecodeValueVisitor<Resolver, TypeIdContext>;
+
 /// Attempt to decode some SCALE encoded bytes into a value, by providing a pointer
 /// to the bytes (which will be moved forwards as bytes are used in the decoding),
 /// a type ID, and a type registry from which we'll look up the relevant type information.
@@ -141,7 +144,7 @@ impl<TypeId> ContextFromTypeId<TypeId> for EmptyContext {
 }
 
 /// Return the type ID for our value context.
-struct TypeIdContext;
+pub struct TypeIdContext;
 impl<TypeId: Clone> ContextFromTypeId<TypeId> for TypeIdContext {
     type Output = TypeId;
     fn context_from_type_id(type_id: &TypeId) -> TypeId {

--- a/src/scale_impls/mod.rs
+++ b/src/scale_impls/mod.rs
@@ -17,5 +17,5 @@ mod decode;
 mod encode;
 mod tracing_decoder;
 
-pub use decode::{decode_composite_as_fields, decode_value_as_type, DecodeError};
+pub use decode::{decode_composite_as_fields, decode_value_as_type, DecodeError, ValueVisitor};
 pub use tracing_decoder::{TraceDecodingError, TraceDecodingVisitor};

--- a/src/string_impls/custom_parsers/ss58.rs
+++ b/src/string_impls/custom_parsers/ss58.rs
@@ -53,7 +53,7 @@ fn parse_ss58_bytes(s: &mut &str) -> Option<Vec<u8>> {
     // If what we are parsing is a variant ident, a `{` or `(` will follow
     // (eg `Foo { hi: 1 }` or `Foo (1)`). In this case, don't try to parse
     // as an ss58 address, since it would definitely be wrong to do so.
-    if rest.trim_start().starts_with(|c| c == '(' || c == '{') {
+    if rest.trim_start().starts_with(['(', '{']) {
         return None;
     }
 


### PR DESCRIPTION
Export `scale_value::scale::ValueVisitor<TypeResolver>`, allowing the values to be created from functions like `scale_decode::visitor::decode_with_visitor`.

The visitor type exported differs from the one you can get back via `Value::into_visitor()` because it puts whatever the type ID is into the value's context, which is useful when printing values with their context to see where things are coming from.