### PR TITLE
remove std features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --all-targets --workspace
+          args: --all-targets --all-features --workspace
 
       - name: Cargo test docs
         uses: actions-rs/cargo@v1.0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.81.0"
 default = ["std", "serde", "from-string", "parser-ss58"]
 
 # Only work in "std" environments:
-std = ["scale-bits/std", "scale-info/std", "either/use_std", "serde?/std", "serde_json/std"]
+std = ["scale-bits/std", "either/use_std", "serde?/std", "serde_json/std"]
 
 # Enable support for parsing strings into Values.
 from-string = ["dep:yap"]
@@ -32,7 +32,6 @@ parser-ss58 = ["dep:base58", "dep:blake2", "from-string"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 serde = { version = "1.0.124", default-features = false, features = ["derive"], optional = true }
-scale-info = { version = "2.11.5", default-features = false }
 scale-decode = { version = "0.15.0", default-features = false }
 scale-encode = { version = "0.9.0", default-features = false, features = ["bits"] }
 scale-bits = { version = "0.6.0", default-features = false, features = ["serde", "scale-info"] }
@@ -47,4 +46,4 @@ scale-type-resolver = "0.2.0"
 hex = "0.4.3"
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
 scale-decode = { version = "0.15.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.5", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 rust-version = "1.81.0"
 
 [features]
-default = ["std", "serde", "from-string", "parser-ss58"]
+default = ["serde", "from-string", "parser-ss58"]
 
-# Only work in "std" environments:
-std = ["scale-bits/std", "either/use_std", "serde?/std", "serde_json/std"]
+# Internal feature for tests that needs std.
+__std = []
 
 # Enable support for parsing strings into Values.
 from-string = ["dep:yap"]

--- a/src/at.rs
+++ b/src/at.rs
@@ -22,7 +22,7 @@ use super::{Composite, Value, ValueDef, Variant};
 use crate::prelude::*;
 
 /// This trait allows indexing into [`Value`]s (and options of [`Value`]s)
-/// using the [`At::at()`] function. It's a little like Rust's [`::std::ops::Index`]
+/// using the [`At::at()`] function. It's a little like Rust's [`core::ops::Index`]
 /// trait, but adapted so that we can return and work with optionals.
 ///
 /// Indexing into a [`Value`] never panics; instead it will return `None` if a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,6 @@ pub mod scale {
 
     pub use crate::scale_impls::{DecodeError, ValueVisitor};
     pub use scale_encode::Error as EncodeError;
-    pub use scale_info::PortableRegistry;
     pub use scale_type_resolver::TypeResolver;
 
     /// Attempt to decode some SCALE encoded bytes into a value, by providing a pointer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ of JSON data).
 
 extern crate alloc;
 
+#[cfg(feature = "__std")]
+extern crate std;
+
 mod at;
 mod macros;
 mod prelude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ of JSON data).
 - Accessed ergonomically via the [`At`] trait.
 */
 #![deny(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,18 +20,12 @@
 // from `core` or `alloc`.
 pub use prelude_contents::*;
 
-#[cfg(feature = "std")]
-mod prelude_contents {
-    pub use std::prelude::rust_2021::*;
-}
-
-#[cfg(not(feature = "std"))]
 mod prelude_contents {
     pub use core::prelude::rust_2021::*;
 
     // The core prelude doesn't include things from
     // `alloc` by default, so add the ones we need that
-    // are otherwose exposed via the std prelude.
+    // are otherwise exposed via the std prelude.
     pub use alloc::borrow::ToOwned;
     pub use alloc::string::{String, ToString};
     pub use alloc::vec::Vec;

--- a/src/scale_impls/decode.rs
+++ b/src/scale_impls/decode.rs
@@ -612,8 +612,7 @@ mod test {
         let scale_info::TypeDef::Composite(c) = &types.resolve(id).unwrap().type_def else {
             panic!("Couldn't get fields");
         };
-        let mut fields =
-            c.fields.iter().map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
+        let mut fields = c.fields.iter().map(|f| scale_decode::Field::new(f.ty.id, f.name));
 
         // get some bytes to decode from:
         let foo = Foo { a: "Hello".to_owned(), b: true, c: 123 };

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -374,7 +374,6 @@ mod test {
     use super::*;
     use crate::value;
     use codec::{Compact, Encode};
-    use core::time::Duration;
     use scale_info::PortableRegistry;
 
     // Panic after some duration.
@@ -635,7 +634,7 @@ mod test {
     #[test]
     #[cfg(feature = "__std")]
     fn encoding_shouldnt_take_forever() {
-        panic_after(Duration::from_millis(100), || {
+        panic_after(core::time::Duration::from_millis(100), || {
             #[derive(scale_info::TypeInfo, codec::Encode)]
             struct A(bool);
 

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -378,13 +378,15 @@ mod test {
     use scale_info::PortableRegistry;
 
     // Panic after some duration.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "__std")]
     fn panic_after<T, F>(d: Duration, f: F) -> T
     where
         T: Send + 'static,
         F: FnOnce() -> T,
         F: Send + 'static,
     {
+        extern crate std;
+
         use std::{sync::mpsc, thread};
 
         let (done_tx, done_rx) = mpsc::channel();
@@ -631,7 +633,7 @@ mod test {
     // Prior to https://github.com/paritytech/scale-value/pulls/48, this test will take
     // too long and panic. #48 should ensure that this doesn't happen.
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "__std")]
     fn encoding_shouldnt_take_forever() {
         panic_after(Duration::from_millis(100), || {
             #[derive(scale_info::TypeInfo, codec::Encode)]

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -384,8 +384,6 @@ mod test {
         F: FnOnce() -> T,
         F: Send + 'static,
     {
-        extern crate std;
-
         use std::{sync::mpsc, thread};
 
         let (done_tx, done_rx) = mpsc::channel();

--- a/src/scale_impls/encode.rs
+++ b/src/scale_impls/encode.rs
@@ -378,7 +378,7 @@ mod test {
 
     // Panic after some duration.
     #[cfg(feature = "__std")]
-    fn panic_after<T, F>(d: Duration, f: F) -> T
+    fn panic_after<T, F>(d: core::time::Duration, f: F) -> T
     where
         T: Send + 'static,
         F: FnOnce() -> T,


### PR DESCRIPTION
This crate doesn't need the std features that were enabled but it will change the prelude that is re-exported.

- either/with-std: enables StdError which is not used
- serde: we don't need the extra std impls that serde provides
- serde_json: uses only `serde_json::from_value` which doesn't need std
- prelude: only core is re-exported now.

Builds on #70 